### PR TITLE
Updating the plugin to be able to set trendlineLinear by dataset

### DIFF
--- a/chartjs-plugin-trendline.js
+++ b/chartjs-plugin-trendline.js
@@ -7,62 +7,70 @@
  * https://github.com/Makanz/chartjs-plugin-trendline/blob/master/README.md
  */
 var pluginTrendlineLinear = {
-	beforeDraw: function(chartInstance) {
-		var yScale = chartInstance.scales["y-axis-0"];
-		var canvas = chartInstance.chart;
-		var ctx = canvas.ctx;
+    beforeDraw: function (chartInstance) {
 
-		if (chartInstance.options.trendlineLinear) {
-			var style = chartInstance.options.trendlineLinear.style;
-			var lineWidth = chartInstance.options.trendlineLinear.width;
-			style = (style !== undefined) ? style : "rgba(169,169,169, .6)";
-			lineWidth = (lineWidth !== undefined) ? lineWidth : 3;
+        var yScale = chartInstance.scales["y-axis-0"],
+            canvas = chartInstance.chart,
+            ctx = canvas.ctx;        
 
-			var data = chartInstance.data.datasets[0].data,
-				lastIndex = data.length - 1,
-				datasetMeta = chartInstance.getDatasetMeta(0),
-				startPos = datasetMeta.data[0]._model.x,
-				endPos = datasetMeta.data[lastIndex]._model.x,
-				fitter = new LineFitter();
+        for (var i = 0; i < chartInstance.data.datasets.length; i++) {
+            
+            if (chartInstance.data.datasets[i].trendlineLinear) {                                               
+                var datasets = chartInstance.data.datasets[i],
+                    datasetMeta = chartInstance.getDatasetMeta(i);                                                     
 
-			for (var i = 0; i < data.length; i++) {
-				fitter.add(i, data[i]);
-			}
-
-			ctx.lineWidth = lineWidth;
-			ctx.beginPath();
-			ctx.moveTo(startPos, yScale.getPixelForValue( fitter.project(0) ));
-			ctx.lineTo(endPos, yScale.getPixelForValue( fitter.project(lastIndex) ));
-			ctx.strokeStyle = style;
-			ctx.stroke();
-		}
-	}
+                addFitter(datasetMeta, ctx, datasets, yScale);
+            }
+        }
+    }
 };
+
+function addFitter(datasetMeta, ctx, datasets, yScale) {
+    
+    var style = datasets.trendlineLinear.style;
+        style = (style !== undefined) ? style : "rgba(169,169,169, .6)";    
+    var lineWidth = datasets.trendlineLinear.width;
+        lineWidth = (lineWidth !== undefined) ? lineWidth : 3;
+
+    var lastIndex = datasets.data.length - 1,
+        startPos = datasetMeta.data[0]._model.x,
+        endPos = datasetMeta.data[lastIndex]._model.x,
+        fitter = new LineFitter();
+
+    for (var i = 0; i < datasets.data.length; i++) {
+        fitter.add(i, datasets.data[i]);
+    }
+
+    ctx.lineWidth = lineWidth;
+    ctx.beginPath();
+    ctx.moveTo(startPos, yScale.getPixelForValue(fitter.project(0)));
+    ctx.lineTo(endPos, yScale.getPixelForValue(fitter.project(lastIndex)));
+    ctx.strokeStyle = style;
+    ctx.stroke();
+}
+
 Chart.plugins.register(pluginTrendlineLinear);
 
-function LineFitter()
-{
-	this.count = 0;
-	this.sumX = 0;
-	this.sumX2 = 0;
-	this.sumXY = 0;
-	this.sumY = 0;
+function LineFitter() {
+    this.count = 0;
+    this.sumX = 0;
+    this.sumX2 = 0;
+    this.sumXY = 0;
+    this.sumY = 0;
 }
 
 LineFitter.prototype = {
-	'add': function(x, y)
-	{
-		this.count++;
-		this.sumX += x;
-		this.sumX2 += x*x;
-		this.sumXY += x*y;
-		this.sumY += y;
-	},
-	'project': function(x)
-	{
-		var det = this.count * this.sumX2 - this.sumX * this.sumX;
-		var offset = (this.sumX2 * this.sumY - this.sumX * this.sumXY) / det;
-		var scale = (this.count * this.sumXY - this.sumX * this.sumY) / det;
-		return offset + x * scale;
-	}
+    'add': function (x, y) {
+        this.count++;
+        this.sumX += x;
+        this.sumX2 += x * x;
+        this.sumXY += x * y;
+        this.sumY += y;
+    },
+    'project': function (x) {
+        var det = this.count * this.sumX2 - this.sumX * this.sumX;
+        var offset = (this.sumX2 * this.sumY - this.sumX * this.sumXY) / det;
+        var scale = (this.count * this.sumXY - this.sumX * this.sumY) / det;
+        return offset + x * scale;
+    }
 };


### PR DESCRIPTION
I needed to add more than one trending line on the same chart, so I changed the code to be able to set  the trendlineLinear option by datasets as bellow:

`datasets: [
                    {
                        type: 'line',
                        label: "Line1",
                        backgroundColor: "#0099c6",
                        borderColor: "#0099c6",
                        borderWidth: 2,
                        fill: false,
                        data: approvalRateData,
                        trendlineLinear: {
                            style: "#0099c6",
                            width: 1
                        },
                    },                   
                        {
                            type: 'line',
                            label: "Line 2",
                            backgroundColor: "#990099",
                            borderColor: "#990099",
                            borderWidth: 2,
                            fill: false,
                            data: conversionRateData,
                            trendlineLinear: {
                                style: "#990099",
                                width: 1
                            },
                        },
                    {
                        type: 'bar',
                        label: "Applications",
                        backgroundColor: "#0089dd",
                        pointStyle: 'rect',
                        pointBorderColor: '#0089dd',
                        data: applicationsData,                        
                    },
]`

result:

![image](https://user-images.githubusercontent.com/367136/37843648-38ac4f80-2ece-11e8-894a-bdf60e520669.png)
