### PR TITLE
Extended configuration about 'lineStyle'

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ This plugin draws an linear trendline in your Chart. Made for Chart.js > 2.0
 
 ## Configuration
 
-To configure the trendline plugin you simply add new config options to your chart config.
+To configure the trendline plugin you simply add new config options for dataset to your chart config.
 
 ```javascript
 {
 	trendlineLinear: {
 		style: "rgba(255,105,180, .8)",
+		lineStyle: "dotted|solid",
 		width: 2
 	}
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-trendline",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Trendline for Chart.js",
   "main": "chartjs-plugin-trendline.js",
   "scripts": {


### PR DESCRIPTION
Extended configuration about 'lineStyle' (can be 'dotted' or 'solid') and use style of dataset border (line color and width) if not overridden by the trendlineLinear configuration + small improvements