### PR TITLE
Display trendline only when dataset is visible

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -12,7 +12,7 @@ var pluginTrendlineLinear = {
         var ctx = chartInstance.chart.ctx;
 
         chartInstance.data.datasets.forEach(function(dataset, index) {
-            if (dataset.trendlineLinear) {
+            if (dataset.trendlineLinear && chartInstance.isDatasetVisible(index)) {
                 var datasetMeta = chartInstance.getDatasetMeta(index);
                 addFitter(datasetMeta, ctx, dataset, yScale);
             }


### PR DESCRIPTION
Honors the display when legend clicked.  Conversely, if the desire is to *only* show the trendline and not the dataset, set showLine: false.