### PR TITLE
Fixed multi-Y-axes issues with trendline

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -24,7 +24,7 @@ var pluginTrendlineLinear = {
         chartInstance.data.datasets.forEach(function(dataset, index) {
             if (dataset.trendlineLinear && chartInstance.isDatasetVisible(index)) {
                 var datasetMeta = chartInstance.getDatasetMeta(index);
-                addFitter(datasetMeta, ctx, dataset, xScale, yScale);
+                addFitter(datasetMeta, ctx, dataset, xScale, chartInstance.scales[datasetMeta.yAxisID]);
             }
         });
 


### PR DESCRIPTION
When using multiple datasets associated with multiple Y axes, the plugin only uses the first Y axis,so only one trendline will be displayed, this change fixes this problem using the correct axis instead of the first axis all time.