### PR TITLE
Auto register plugin only when global Chart is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,30 @@
 
 This plugin draws an linear trendline in your Chart. Made for Chart.js > 2.0
 
+## Installation
+
+#### Load directly in the browser
+
+Load ChartJS first, then the plugin which will automatically register itself with ChartJS
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/chart.js/dist/Chart.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-trendline"></script>
+```
+
+#### As a Chart.JS plugin
+
+Install & import the plugin via npm:
+
+`npm i chart.js chartjs-plugin-trendline`
+
+```js
+import ChartJS from "chart.js";
+import chartTrendline from "chartjs-plugin-trendline";
+
+ChartJS.plugins.register(chartTrendline);
+```
+
 ## Configuration
 
 To configure the trendline plugin you simply add a new config options to your dataset in your chart config.
@@ -16,11 +40,10 @@ To configure the trendline plugin you simply add a new config options to your da
 }
 ```
 
-
 ## Supported chart types
 
-* bar
-* line
+-   bar
+-   line
 
 ## Contributing
 

--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -9,6 +9,7 @@
  * Mod by: vesal: accept also xy-data so works with scatter
  */
 var pluginTrendlineLinear = {
+    id: "trendlineLinear",
     beforeDraw: function(chartInstance) {
         var yScale;
         var xScale;
@@ -91,8 +92,6 @@ function addFitter(datasetMeta, ctx, dataset, xScale, yScale) {
     ctx.stroke();
 }
 
-Chart.plugins.register(pluginTrendlineLinear);
-
 function LineFitter() {
     this.count = 0;
     this.sumX = 0;
@@ -120,3 +119,12 @@ LineFitter.prototype = {
         return offset + x * scale;
     }
 };
+
+// If we're in the browser and have access to the global Chart obj, register plugin automatically
+if (typeof window !== "undefined" && window.Chart)
+    window.Chart.plugins.register(pluginTrendlineLinear);
+
+// Otherwise, try to export the plugin
+try {
+    module.exports = exports = pluginTrendlineLinear;
+} catch (e) {}


### PR DESCRIPTION
Basically, can use this plugin as a regular plugin (import, register, use) while keeping the current behaviour of auto-registering itself in the browser when it can.

My use case here is I'm using a server side ChartJS renderer and in this context there's no global "Chart" object.

I've updated the readme as well to document the two ways of using the plugin.