### PR TITLE
Support timeseries

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -49,9 +49,11 @@ function addFitter(datasetMeta, ctx, dataset, xScale, yScale) {
     if ( dataset.data && typeof dataset.data[0] === 'object') xy = true;
 
     dataset.data.forEach(function(data, index) {
-        if(data == null)
-            return;
-        if ( xy ) fitter.add(data.x, data.y);
+        if (data == null) return;
+
+        if (xScale.options.type === "time")
+            fitter.add(new Date(data.x).getTime(), data.y);
+        else if (xy) fitter.add(data.x, data.y);
         else fitter.add(index, data);
     });
 


### PR DESCRIPTION
If the scale type is a timeseries, calculations will be based on the timestamp gathered from the x axis

Should allow this plugin to work out of the box with most charts (doesn't affect non-timeseries charts)