### PR TITLE
Don't attempt to draw trendline for an empty dataset

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -23,7 +23,7 @@ var pluginTrendlineLinear = {
         var ctx = chartInstance.chart.ctx;
 
         chartInstance.data.datasets.forEach(function(dataset, index) {
-            if (dataset.trendlineLinear && chartInstance.isDatasetVisible(index)) {
+            if (dataset.trendlineLinear && chartInstance.isDatasetVisible(index) && dataset.data.length != 0) {
                 var datasetMeta = chartInstance.getDatasetMeta(index);
                 addFitter(datasetMeta, ctx, dataset, xScale, chartInstance.scales[datasetMeta.yAxisID]);
             }


### PR DESCRIPTION
As title. If a dataset has no data points in it, the `addFitter` method is not run for that dataset.

Resolves #42 when merged.