### PR TITLE
Handle null values

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -55,7 +55,7 @@ function addFitter(datasetMeta, ctx, dataset, xScale, yScale) {
     var endPos = datasetMeta.data[lastIndex].x
 
     var xy = false
-    if (dataset.data && typeof dataset.data[0] === 'object') xy = true
+    if (dataset.data && dataset.data[0] && typeof dataset.data[0] === 'object') xy = true
 
     dataset.data.forEach(function (data, index) {
         if (data == null) return


### PR DESCRIPTION
It's currently possible for null values in a dataset to prevent a trendline from showing up when using datasets backed by primitive arrays instead of objects.

On the following line, if `dataset.data[0]` is `null` then `typeof dataset.data[0] === 'object'` will return true as `null` is an object. This then causes the data points to be treated as `xy` objects possibly incorrect and everything breaks down from there.
```
if (dataset.data && dataset.data[0] && typeof dataset.data[0] === 'object') xy = true
```

The fix is simply to check if `dataset.data[0]` is `null` or not.

I'm assuming this would fix #34.