### PR TITLE
fix undefined data point handling

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -50,12 +50,13 @@ function addFitter(datasetMeta, ctx, dataset, xScale, yScale) {
     lineWidth = lineWidth !== undefined ? lineWidth : 3
 
     var fitter = new LineFitter()
+    var firstIndex = dataset.data.findIndex(d => {
+        return d !== undefined && d !== null
+    })
     var lastIndex = dataset.data.length - 1
-    var startPos = datasetMeta.data[0].x
+    var startPos = datasetMeta.data[firstIndex].x
     var endPos = datasetMeta.data[lastIndex].x
-
-    var xy = false
-    if (dataset.data && typeof dataset.data[0] === 'object') xy = true
+    var xy = typeof dataset.data[firstIndex] === 'object'
 
     dataset.data.forEach(function (data, index) {
         if (data == null) return


### PR DESCRIPTION
Changed to find the first defined data item and use it to establish first position. Index can also be used to more accurately check if the data is an object type.
ref #34 

```javascript
var xy = false
if (dataset.data && typeof dataset.data[0] === 'object') xy = true
```
The above was replaced because the condition returns a boolean so we don't need an `if` statement to fill the boolean. Also, by this point `dataset.data` has already been checked and/or accessed, so we only need to check if a defined value is an object type.

Is there a reason not to terminate lines with `;`?