### PR TITLE
change: enable `addFitter` when there are more than 1 points

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -24,7 +24,7 @@ var pluginTrendlineLinear = {
             if (
                 dataset.trendlineLinear &&
                 chartInstance.isDatasetVisible(index) &&
-                dataset.data.length != 0
+                dataset.data.length > 1
             ) {
                 var datasetMeta = chartInstance.getDatasetMeta(index);
                 addFitter(


### PR DESCRIPTION
Since we need at least 2 points to make the trend line, I think we can perform `addFitter` when there is more that 1 points