### PR TITLE
Option to always show trendline

### DIFF
--- a/src/chartjs-plugin-trendline.js
+++ b/src/chartjs-plugin-trendline.js
@@ -21,9 +21,11 @@ var pluginTrendlineLinear = {
         var ctx = chartInstance.ctx;
 
         chartInstance.data.datasets.forEach(function (dataset, index) {
+            var showTrendline = dataset.alwaysShowTrendline || chartInstance.isDatasetVisible(index);
+
             if (
                 dataset.trendlineLinear &&
-                chartInstance.isDatasetVisible(index) &&
+                showTrendline &&
                 dataset.data.length > 1
             ) {
                 var datasetMeta = chartInstance.getDatasetMeta(index);


### PR DESCRIPTION
The trendline was hidden by default when the dataset was hidden, this PR adds the option to always show the trendline regardless the dataset visibility.