### PR TITLE
Fix: Correct trendline rendering, projection, and data accuracy

### DIFF
--- a/example/lineChartProjection.html
+++ b/example/lineChartProjection.html
@@ -5,43 +5,150 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta http-equiv="X-UA-Compatible" content="ie=edge">
-    <title>XYlineChart Projection Example</title>
+    <title>Trendline Projection & Offset Example</title>
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.9/dist/chart.umd.js"></script>
     <script src="../dist/chartjs-plugin-trendline.min.js"></script>
+    <style>
+        .chart-container {
+            width: 800px;
+            height: 500px;
+            margin-bottom: 50px;
+        }
+        body {
+            font-family: Arial, sans-serif;
+            margin: 20px;
+        }
+        h1, h2 {
+            text-align: center;
+        }
+    </style>
     <script>
         document.addEventListener("DOMContentLoaded", function (event) {
             new Chart(document.getElementById("line-chart"), {
                 type: 'line',
                 data: {
-                    datasets: [{
+                    datasets: [
+                    {
+                        // Dataset 1: Original data, demonstrates basic projection.
+                        // Observe: Trendline extends to the edges of the chart area.
                         data: [{ x: 0, y: 30 }, { x: 5, y: 25 }, { x: 10, y: 23 }, { x: 25, y: 23 }, { x: 35, y: 17 }, { x: 45, y: 17 }],
-                        label: "Count",
+                        label: "Dataset 1 (Projected)",
                         borderColor: "#3e95cd",
+                        backgroundColor: "rgba(62,149,205,0.1)",
                         fill: false,
                         trendlineLinear: {
-                            colorMin: "#3e95cd",
-                            lineStyle: "line",
-                            width: 1,
-                            projection: true
+                            colorMin: "#3e95cd", // Should match borderColor or be distinct
+                            lineStyle: "dotted", // "line" was not a valid Chart.js option, "solid" or "dotted", "dashed"
+                            width: 2,
+                            projection: true,
+                            label: {
+                                display: true,
+                                text: "Trend D1 (Proj)",
+                                displayValue: true,
+                            }
                         }
                     },
                     {
-                        data: [{ x: 60, y: 0 }],
-                        borderColor: "black",
-                        label: "Goal",
-                        fill: false
-                    }]
+                        // Dataset 2: Clustered data, non-projected.
+                        // Observe: Trendline only spans the range of its data points (approx x=15 to x=35).
+                        // This contrasts with projected lines that extend to chart boundaries.
+                        data: [{ x: 15, y: 10 }, { x: 20, y: 12 }, { x: 25, y: 9 }, { x: 30, y: 11 }, { x: 35, y: 8 }],
+                        label: "Dataset 2 (Non-Projected, Clustered)",
+                        borderColor: "#FF6384",
+                        backgroundColor: "rgba(255,99,132,0.1)",
+                        fill: false,
+                        trendlineLinear: {
+                            colorMin: "#FF6384",
+                            lineStyle: "dashed",
+                            width: 2,
+                            projection: false, // Explicitly false
+                            label: {
+                                display: true,
+                                text: "Trend D2 (No Proj)",
+                                displayValue: true,
+                            }
+                        }
+                    },
+                    {
+                        // Dataset 3: Projected, with positive trendoffset and null data points.
+                        // Observe: Trendline calculation starts after skipping the first 2 data points (due to trendoffset: 2).
+                        // Null values (e.g., at x=65) are correctly ignored by the fitter. The line projects to chart edges.
+                        data: [{ x: 50, y: 10 }, { x: 55, y: 12 }, { x: 60, y: 15 }, null, { x: 70, y: 18 }, { x: 75, y: 22 }, {x: 65, y: null}],
+                        label: "Dataset 3 (Projected, Offset+, Nulls)",
+                        borderColor: "#4BC0C0",
+                        backgroundColor: "rgba(75,192,192,0.1)",
+                        fill: false,
+                        trendlineLinear: {
+                            colorMin: "#4BC0C0",
+                            lineStyle: "solid",
+                            width: 2,
+                            projection: true,
+                            trendoffset: 2, // Skips first 2 data points from calculation {50,y:10}, {55,y:12}
+                            label: {
+                                display: true,
+                                text: "Trend D3 (Proj, Offset+)",
+                                displayValue: true,
+                            }
+                        }
+                    },
+                    {
+                        // Dataset 4: Projected, with negative trendoffset.
+                        // Observe: Trendline calculation excludes the last 2 data points from the set.
+                        // The line projects to chart edges based on the remaining points.
+                        data: [{ x: 0, y: 5 }, { x: 10, y: 8 }, { x: 20, y: 6}, { x: 30, y: 9 }, { x: 40, y: 7 }, { x: 50, y: 10 } ],
+                        label: "Dataset 4 (Projected, Offset-)",
+                        borderColor: "#FF9F40",
+                        backgroundColor: "rgba(255,159,64,0.1)",
+                        fill: false,
+                        trendlineLinear: {
+                            colorMin: "#FF9F40",
+                            lineStyle: "dotted",
+                            width: 2,
+                            projection: true,
+                            trendoffset: -2, // Excludes last 2 data points {40,y:7}, {50,y:10}
+                            label: {
+                                display: true,
+                                text: "Trend D4 (Proj, Offset-)",
+                                displayValue: true,
+                            }
+                        }
+                    },
+                    // Dummy dataset to ensure chart scales to desired max, if other data doesn't reach it.
+                    // { data: [{ x: 80, y: 35 }], label: "ScaleHelper", hidden: true}
+                    ]
                 },
                 options: {
-                    title: {
-                        display: true,
-                        text: 'Cigarettes per days',
+                    plugins: {
+                        title: {
+                            display: true,
+                            text: 'Trendline Projection, Offset, and Data Handling Demo',
+                            font: { size: 18 }
+                        },
+                        legend: {
+                            position: 'top',
+                        },
+                        tooltip: {
+                            mode: 'index',
+                            intersect: false,
+                        }
                     },
-                    maintainAspectRatio: true,
+                    maintainAspectRatio: false,
                     responsive: true,
                     scales: {
-                        x: { type: 'linear', position: 'bottom', scaleLabel: { labelString: 'days', display: true } },
-                        y: { type: 'linear', position: 'left', scaleLabel: { labelString: 'cigarretts/day', display: true }, display: true },
+                        x: {
+                            type: 'linear',
+                            position: 'bottom',
+                            title: { text: 'X Value / Days', display: true },
+                            min: -5,   // Adjusted min to give space
+                            max: 80,  // Adjusted max to give space for projection
+                        },
+                        y: {
+                            type: 'linear',
+                            position: 'left',
+                            title: { text: 'Y Value / Count', display: true },
+                            min: 0,   // Adjusted min
+                            max: 35,  // Adjusted max
+                        }
                     }
                 }
             });
@@ -50,10 +157,34 @@
 </head>
 
 <body>
-    <h1>X/Y Chart with trendline projection on x axis</h1>
+    <h1>Chart.js Trendline Plugin Demonstration</h1>
+    <h2>Projection, Data Offset, and Null Value Handling</h2>
 
-    <div style="width: 800px; height: 450px;">
+    <div class="chart-container">
         <canvas id="line-chart"></canvas>
+    </div>
+
+    <div style="padding: 20px; background-color: #f4f4f4; border-radius: 5px;">
+        <h3>Observations Guide:</h3>
+        <ul>
+            <li><strong>Dataset 1 (Blue, Dotted Trend):</strong> Shows a standard projected trendline extending to the chart's X-axis boundaries.</li>
+            <li><strong>Dataset 2 (Red, Dashed Trend):</strong> Demonstrates a <strong>non-projected</strong> trendline. Notice how it only covers the span of its own data points (approx. x=15 to x=35).</li>
+            <li><strong>Dataset 3 (Teal, Solid Trend):</strong>
+                <ul>
+                    <li>Uses <code>projection: true</code>.</li>
+                    <li><code>trendoffset: 2</code> means the first two data points ( (50,10) and (55,12) ) are excluded from the trendline calculation.</li>
+                    <li>Contains a <code>null</code> data point (originally at x=65) which is correctly ignored by the trendline fitter.</li>
+                </ul>
+            </li>
+            <li><strong>Dataset 4 (Orange, Dotted Trend):</strong>
+                <ul>
+                    <li>Uses <code>projection: true</code>.</li>
+                    <li><code>trendoffset: -2</code> means the last two data points ( (40,7) and (50,10) ) are excluded from the trendline calculation.</li>
+                </ul>
+            </li>
+            <li>All trendlines should be clipped correctly within the chart area boundaries, even if their mathematical extension would go beyond.</li>
+            <li>The slope displayed in the labels should consistently reflect the underlying data used for fitting, regardless of projection.</li>
+        </ul>
     </div>
 
 </body>

--- a/src/components/trendline.js
+++ b/src/components/trendline.js
@@ -51,156 +51,319 @@ export const addFitter = (datasetMeta, ctx, dataset, xScale, yScale) => {
 
     let fitter = new LineFitter();
     
-    // Handle trendoffset
+    // --- Data Point Collection and Validation for LineFitter ---
+
+    // Sanitize trendoffset: if its absolute value is too large, reset to 0.
+    // This prevents errors if offset is out of bounds of the dataset length.
     if (Math.abs(trendoffset) >= dataset.data.length) trendoffset = 0;
     
-    // Calculate firstIndex based on trendoffset
-    let firstIndex = ((trendoffset < 0) ? dataset.data.length : 0) + trendoffset + dataset.data.slice(trendoffset).findIndex((d) => {
-        return d !== undefined && d !== null;
-    });
+    // Determine the actual starting index for data processing if a positive trendoffset is applied.
+    // This skips initial data points and finds the first non-null data point thereafter.
+    // `effectiveFirstIndex` is used to determine the data type ('xy' or array) and to skip initial points for positive offset.
+    let effectiveFirstIndex = 0;
+    if (trendoffset > 0) {
+        // Start searching for a non-null point from the offset.
+        const firstNonNullAfterOffset = dataset.data.slice(trendoffset).findIndex((d) => d !== undefined && d !== null);
+        if (firstNonNullAfterOffset !== -1) {
+            effectiveFirstIndex = trendoffset + firstNonNullAfterOffset;
+        } else {
+            // All points after the offset are null or undefined, so effectively no data for trendline.
+            effectiveFirstIndex = dataset.data.length; 
+        }
+    } else {
+        // For zero or negative offset, the initial search for 'xy' type detection starts from the beginning of the dataset.
+        // The actual exclusion of points for negative offset (from the end) is handled per-point within the loop.
+        const firstNonNull = dataset.data.findIndex((d) => d !== undefined && d !== null);
+        if (firstNonNull !== -1) {
+            effectiveFirstIndex = firstNonNull;
+        } else {
+            // All data in the dataset is null or undefined.
+            effectiveFirstIndex = dataset.data.length; 
+        }
+    }
     
-    let lastIndex = dataset.data.length - 1;
-    let startPos = datasetMeta.data[firstIndex]?.[xAxisKey];
-    let endPos = datasetMeta.data[lastIndex]?.[xAxisKey];
-    let xy = typeof dataset.data[firstIndex] === 'object';
+    // Determine data structure type (object {x,y} or array of numbers) based on the first valid data point.
+    // This informs how `xAxisKey` and `yAxisKey` are used or if `index` is used for x-values.
+    let xy = effectiveFirstIndex < dataset.data.length && typeof dataset.data[effectiveFirstIndex] === 'object';
 
-    // Collect data points for the fitter, respecting the trendoffset
+    // Iterate over dataset to collect points for the LineFitter.
     dataset.data.forEach((data, index) => {
-        if (data == null) return;
+        // Skip any data point that is null or undefined directly. This is a general guard.
+        if (data == null) return; 
         
-        // Skip data points outside the offset range
-        if (trendoffset > 0 && index < firstIndex) return;
-        if (trendoffset < 0 && index < dataset.data.length + trendoffset) return;
+        // Apply trendoffset logic for including/excluding points:
+        // 1. Positive offset: Skip data points if their index is before the `effectiveFirstIndex`.
+        //    `effectiveFirstIndex` already accounts for the offset and initial nulls.
+        if (trendoffset > 0 && index < effectiveFirstIndex) return;
+        // 2. Negative offset: Skip data points if their index is at or after the calculated end point.
+        //    `dataset.data.length + trendoffset` marks the first index of the points to be excluded from the end.
+        //    For example, if length is 10 and offset is -2, points from index 8 onwards are skipped.
+        if (trendoffset < 0 && index >= dataset.data.length + trendoffset) return;
 
+        // Process data based on scale type and data structure.
         if (['time', 'timeseries'].includes(xScale.options.type)) {
-            let x = data[xAxisKey] != null ? data[xAxisKey] : data.t; // data.t is a fallback
+            // For time-based scales, convert x to a numerical timestamp; ensure y is a valid number.
+            let x = data[xAxisKey] != null ? data[xAxisKey] : data.t; // `data.t` is a Chart.js internal fallback for time data.
             const yValue = data[yAxisKey];
 
-            // For timeseries, we need a valid time value for x and a valid numeric value for y.
-            // x !== undefined was the original check for x, but also check yValue.
+            // Both x and y must be valid for the point to be included.
             if (x != null && x !== undefined && yValue != null && !isNaN(yValue)) {
                 fitter.add(new Date(x).getTime(), yValue);
             }
-            // If x is undefined or null, or yValue is invalid, the point is skipped for timeseries.
-            // The original 'else { fitter.add(index, data) }' was problematic for object data in timeseries.
-        } else if (xy) { // xy is true if typeof dataset.data[firstIndex] === 'object'
+            // If x or yValue is invalid, the point is skipped.
+        } else if (xy) { // Data is identified as array of objects {x,y}.
             const xVal = data[xAxisKey];
             const yVal = data[yAxisKey];
 
             const xIsValid = xVal != null && !isNaN(xVal);
             const yIsValid = yVal != null && !isNaN(yVal);
 
+            // Both xVal and yVal must be valid numbers to include the point.
             if (xIsValid && yIsValid) {
                 fitter.add(xVal, yVal);
-            } else if (xIsValid) { // yVal is invalid or null
-                fitter.add(index, xVal); // Use index for X, xVal for Y (matches original behavior pattern)
-            } else if (yIsValid) { // xVal is invalid or null
-                fitter.add(index, yVal); // Use index for X, yVal for Y (matches original behavior pattern)
             }
-            // If both xVal and yVal are invalid, the point is skipped.
-        } else {
-            // This branch is for non-object data (e.g. array of numbers)
+            // If either xVal or yVal is invalid, the point is skipped. No fallback to using index.
+        } else { 
+            // Data is an array of numbers (or other non-object types).
+            // The 'data' variable itself is the y-value, and 'index' is the x-value.
+            // We still need to check for null/NaN here because 'data' (the y-value) could be null/NaN
+            // even if the entry 'data' (the point/container) wasn't null in the initial check.
+            // This applies if dataset.data = [1, 2, null, 4].
             if (data != null && !isNaN(data)) {
                  fitter.add(index, data);
             }
         }
     });
 
-    // Calculate the pixel coordinates for the trendline
-    let x1 = isFinite(startPos)
-        ? startPos
-        : xScale.getPixelForValue(fitter.minx);
-    let y1 = yScaleToUse.getPixelForValue(fitter.f(fitter.minx));
-    let x2, y2;
+    // --- Trendline Coordinate Calculation ---
+    // These variables will hold the pixel coordinates for drawing the trendline.
+    let x1_px, y1_px, x2_px, y2_px; 
 
-    // Projection logic for trendline
-    if (dataset.trendlineLinear.projection && fitter.scale() < 0) {
-        let x2value = fitter.fo();
-        if (x2value < fitter.minx) x2value = fitter.maxx;
-        x2 = xScale.getPixelForValue(x2value);
-        y2 = yScaleToUse.getPixelForValue(fitter.f(x2value));
-    } else {
-        x2 = isFinite(endPos) ? endPos : xScale.getPixelForValue(fitter.maxx);
-        y2 = yScaleToUse.getPixelForValue(fitter.f(fitter.maxx));
-    }
+    const chartArea = datasetMeta.controller.chart.chartArea; // Defines the drawable area in pixels.
 
-    const drawBottom = datasetMeta.controller.chart.chartArea.bottom;
-    const chartWidth = datasetMeta.controller.chart.width;
+    // Determine trendline start/end points based on the 'projection' option.
+    if (dataset.trendlineLinear.projection) {
+        // Projected trendline: Extends to the edges of the chart's data coordinate system.
+        const slope = fitter.slope();
+        const intercept = fitter.intercept();
+        let points = []; // Stores potential {x, y} data points for the line ends, in data values.
 
-    // Only adjust line for overflow if coordinates are valid
-    if (isFinite(x1) && isFinite(y1) && isFinite(x2) && isFinite(y2)) {
-        adjustLineForOverflow({ x1, y1, x2, y2, drawBottom, chartWidth });
+        // Calculate intersections of the trendline with the chart boundaries.
+        // These calculations use data values, not pixel values directly.
+        // Avoid division by zero for vertical or near-vertical lines when calculating x from y.
+        if (Math.abs(slope) > 1e-6) { // If the line is not perfectly horizontal.
+            // Intersection with top boundary (y-value from chartArea.top, converted to data scale).
+            const val_y_top = yScaleToUse.getValueForPixel(chartArea.top);
+            const x_at_top = (val_y_top - intercept) / slope; // x = (y - c) / m
+            points.push({ x: x_at_top, y: val_y_top });
 
-        // Set line width and styles
-        ctx.lineWidth = lineWidth;
-        setLineStyle(ctx, lineStyle);
-
-        // Draw the trendline
-        drawTrendline({ ctx, x1, y1, x2, y2, colorMin, colorMax });
-
-        // Optionally fill below the trendline
-        if (fillColor) {
-            fillBelowTrendline(ctx, x1, y1, x2, y2, drawBottom, fillColor);
+            // Intersection with bottom boundary (y-value from chartArea.bottom, converted to data scale).
+            const val_y_bottom = yScaleToUse.getValueForPixel(chartArea.bottom);
+            const x_at_bottom = (val_y_bottom - intercept) / slope; // x = (y - c) / m
+            points.push({ x: x_at_bottom, y: val_y_bottom });
+        } else { // Line is horizontal (slope is effectively zero).
+            // For a horizontal line, y is constant (the intercept).
+            // The line extends from the leftmost to the rightmost data values of the chart area.
+             points.push({ x: xScale.getValueForPixel(chartArea.left), y: intercept});
+             points.push({ x: xScale.getValueForPixel(chartArea.right), y: intercept});
         }
 
-        // Calculate the angle of the trendline
-        const angle = Math.atan2(y2 - y1, x2 - x1);
+        // Intersection with left boundary (x-value from chartArea.left, converted to data scale).
+        const val_x_left = xScale.getValueForPixel(chartArea.left);
+        const y_at_left = fitter.f(val_x_left); // y = m*x + c
+        points.push({ x: val_x_left, y: y_at_left });
 
-        // Calculate the slope of the trendline (value of trend)
-        const slope = (y1 - y2) / (x2 - x1);
+        // Intersection with right boundary (x-value from chartArea.right, converted to data scale).
+        const val_x_right = xScale.getValueForPixel(chartArea.right);
+        const y_at_right = fitter.f(val_x_right); // y = m*x + c
+        points.push({ x: val_x_right, y: y_at_right });
+        
+        // Filter calculated intersection points: only keep those within the chart's actual data value range.
+        // This ensures that only intersections on the visible chart segments are considered.
+        const chartMinX = xScale.getValueForPixel(chartArea.left); // Min X data value on chart
+        const chartMaxX = xScale.getValueForPixel(chartArea.right); // Max X data value on chart
+        const chartMinY = yScaleToUse.getValueForPixel(chartArea.bottom); // Min Y data value (yScale is inverted in pixels)
+        const chartMaxY = yScaleToUse.getValueForPixel(chartArea.top);    // Max Y data value
 
-        // Add the label to the trendline if it's populated and not set to hidden
-        if (dataset.trendlineLinear.label && display !== false) {
-            const trendText = displayValue
-                ? `${text} (Slope: ${
-                      percentage
-                          ? (slope * 100).toFixed(2) + '%'
-                          : slope.toFixed(2)
-                  })`
-                : text;
-            addTrendlineLabel(
-                ctx,
-                trendText,
-                x1,
-                y1,
-                x2,
-                y2,
-                angle,
-                color,
-                family,
-                size,
-                offset
-            );
+        let validPoints = points.filter(p => 
+            p.x >= chartMinX && p.x <= chartMaxX && p.y >= chartMinY && p.y <= chartMaxY
+        );
+
+        // Remove duplicate points (e.g., if an intersection point is also a corner of the chart area).
+        // This can happen if the trendline passes exactly through a corner.
+        validPoints = validPoints.filter((point, index, self) =>
+            index === self.findIndex((t) => (
+                Math.abs(t.x - point.x) < 1e-4 && Math.abs(t.y - point.y) < 1e-4 // Tolerance for float comparison
+            ))
+        );
+        
+        if (validPoints.length >= 2) {
+            // Sort points (e.g., by x-coordinate, then y) to pick the two extremes that define the line segment.
+            validPoints.sort((a,b) => a.x - b.x || a.y - b.y); 
+
+            // Convert these two chosen data points (which are in data values) to pixel coordinates for drawing.
+            x1_px = xScale.getPixelForValue(validPoints[0].x);
+            y1_px = yScaleToUse.getPixelForValue(validPoints[0].y);
+            x2_px = xScale.getPixelForValue(validPoints[validPoints.length - 1].x);
+            y2_px = yScaleToUse.getPixelForValue(validPoints[validPoints.length - 1].y);
+        } else {
+            // Fallback: Not enough valid intersection points (line likely entirely outside chart area, or error).
+            // Setting coordinates to NaN prevents drawing.
+            x1_px = NaN; y1_px = NaN; x2_px = NaN; y2_px = NaN;
+        }
+
+    } else {
+        // Non-projected trendline: Drawn only between the min and max x-values of the *fitted data points*.
+        // It does not extend to the edges of the chart area unless min/max x of data coincide with chart edges.
+        const y_at_minx = fitter.f(fitter.minx); // y = slope * min_x_of_data + intercept
+        const y_at_maxx = fitter.f(fitter.maxx); // y = slope * max_x_of_data + intercept
+
+        // Convert these min/max data points to pixel coordinates.
+        x1_px = xScale.getPixelForValue(fitter.minx);
+        y1_px = yScaleToUse.getPixelForValue(y_at_minx);
+        x2_px = xScale.getPixelForValue(fitter.maxx);
+        y2_px = yScaleToUse.getPixelForValue(y_at_maxx);
+    }
+
+    // --- Line Clipping and Drawing ---
+    // At this point, x1_px, y1_px, x2_px, y2_px are calculated (in pixels) based on projection or non-projection.
+    // Apply Liang-Barsky clipping algorithm to ensure the line segment stays within the drawable chartArea.
+
+    let clippedCoords = null;
+    // Ensure coordinates are finite numbers before attempting to clip.
+    if (isFinite(x1_px) && isFinite(y1_px) && isFinite(x2_px) && isFinite(y2_px)) {
+        // liangBarskyClip operates on pixel coordinates against the pixel-defined chartArea.
+        clippedCoords = liangBarskyClip(x1_px, y1_px, x2_px, y2_px, chartArea);
+    }
+
+    // Only proceed with drawing if the line is valid and clipping results in a visible line segment.
+    if (clippedCoords) {
+        x1_px = clippedCoords.x1;
+        y1_px = clippedCoords.y1;
+        x2_px = clippedCoords.x2;
+        y2_px = clippedCoords.y2;
+
+        // Ensure the clipped line has a non-zero length (e.g., > 0.5 pixels) to be drawn.
+        // This avoids drawing artifacts for lines that are clipped to what is effectively a single point.
+        if (Math.abs(x1_px - x2_px) < 0.5 && Math.abs(y1_px - y2_px) < 0.5) { 
+            // Line is too short to be drawn or is clipped to a point, effectively invisible.
+        } else {
+            // Set line width and visual styles for drawing.
+            ctx.lineWidth = lineWidth;
+            setLineStyle(ctx, lineStyle);
+
+            // Draw the (now clipped) trendline.
+            drawTrendline({ ctx, x1: x1_px, y1: y1_px, x2: x2_px, y2: y2_px, colorMin, colorMax });
+
+            // Optionally fill the area below the trendline.
+            if (fillColor) {
+                fillBelowTrendline(ctx, x1_px, y1_px, x2_px, y2_px, chartArea.bottom, fillColor);
+            }
+
+            // Calculate the angle of the final (clipped) trendline for label positioning.
+            const angle = Math.atan2(y2_px - y1_px, x2_px - x1_px);
+
+            // Use `fitter.slope()` for the label text. This ensures consistency with the underlying data model,
+            // as the pixel-based slope of the drawn line can vary due to projection and clipping.
+            const displaySlope = fitter.slope();
+
+            // Add the label to the trendline if configured to be displayed.
+            if (dataset.trendlineLinear.label && display !== false) {
+                const trendText = displayValue
+                    ? `${text} (Slope: ${
+                          percentage
+                              ? (displaySlope * 100).toFixed(2) + '%' // Display as percentage if opted
+                              : displaySlope.toFixed(2)
+                      })`
+                    : text;
+                addTrendlineLabel(
+                    ctx,
+                    trendText,
+                    x1_px, // Use final clipped coordinates for label positioning.
+                    y1_px,
+                    x2_px,
+                    y2_px,
+                    angle,
+                    color,
+                    family,
+                    size,
+                    offset
+                );
+            }
         }
     }
 };
 
 /**
- * Adjusts the line if it overflows below the chart bottom.
- * @param {Object} params - The line parameters.
- * @param {number} params.x1 - Starting x-coordinate of the trendline.
- * @param {number} params.y1 - Starting y-coordinate of the trendline.
- * @param {number} params.x2 - Ending x-coordinate of the trendline.
- * @param {number} params.y2 - Ending y-coordinate of the trendline.
- * @param {number} params.drawBottom - Bottom boundary of the chart.
- * @param {number} params.chartWidth - Width of the chart.
+ * Clips a line segment to a rectangular clipping window using the Liang-Barsky algorithm.
+ * This algorithm is efficient for 2D line clipping against an axis-aligned rectangle.
+ * It determines the portion of the line segment (x1,y1)-(x2,y2) that is visible within
+ * the rectangle defined by chartArea {left, right, top, bottom}.
+ * @param {number} x1 - Pixel coordinate for the start of the line (x-axis).
+ * @param {number} y1 - Pixel coordinate for the start of the line (y-axis).
+ * @param {number} x2 - Pixel coordinate for the end of the line (x-axis).
+ * @param {number} y2 - Pixel coordinate for the end of the line (y-axis).
+ * @param {Object} chartArea - The chart area with { left, right, top, bottom } pixel boundaries.
+ * @returns {Object|null} An object with { x1, y1, x2, y2 } of the clipped line, 
+ *                        or null if the line is entirely outside the window or clipped to effectively a point.
  */
-const adjustLineForOverflow = ({ x1, y1, x2, y2, drawBottom, chartWidth }) => {
-    if (y1 > drawBottom) {
-        let diff = y1 - drawBottom;
-        let lineHeight = y1 - y2;
-        let overlapPercentage = diff / lineHeight;
-        let addition = chartWidth * overlapPercentage;
+function liangBarskyClip(x1, y1, x2, y2, chartArea) {
+    let dx = x2 - x1; // Change in x
+    let dy = y2 - y1; // Change in y
+    let t0 = 0.0;     // Parameter for the start of the clipped line segment (initially at x1, y1).
+                      // Represents the proportion along the line from (x1,y1) to (x2,y2).
+    let t1 = 1.0;     // Parameter for the end of the clipped line segment (initially at x2, y2).
 
-        y1 = drawBottom;
-        x1 = x1 + addition;
-    } else if (y2 > drawBottom) {
-        let diff = y2 - drawBottom;
-        let lineHeight = y2 - y1;
-        let overlapPercentage = diff / lineHeight;
-        let subtraction = chartWidth - chartWidth * overlapPercentage;
+    // p and q arrays are used in the Liang-Barsky algorithm conditions.
+    // For each of the 4 clip edges (left, right, top, bottom):
+    // p[k] * t >= q[k]
+    // p values: -dx (left), dx (right), -dy (top), dy (bottom)
+    // q values: x1 - x_min (left), x_max - x1 (right), y1 - y_min (top), y_max - y1 (bottom)
+    // Note: Canvas y-coordinates increase downwards, so chartArea.top < chartArea.bottom.
+    const p = [-dx, dx, -dy, dy];
+    const q = [
+        x1 - chartArea.left,    // q[0] for left edge check
+        chartArea.right - x1,   // q[1] for right edge check
+        y1 - chartArea.top,     // q[2] for top edge check
+        chartArea.bottom - y1,  // q[3] for bottom edge check
+    ];
 
-        y2 = drawBottom;
-        x2 = chartWidth - (x2 - subtraction);
+    for (let i = 0; i < 4; i++) { // Iterate through the 4 clip edges (left, right, top, bottom).
+        if (p[i] === 0) { // Line is parallel to the i-th clipping edge.
+            if (q[i] < 0) { // Line is outside this parallel edge (e.g., for left edge, x1 < chartArea.left).
+                return null; // Line is completely outside, so reject.
+            }
+            // If q[i] >= 0, line is inside or on the parallel edge, so this edge doesn't clip it. Continue.
+        } else {
+            const r = q[i] / p[i]; // Parameter t where the line intersects this edge's infinite line.
+            if (p[i] < 0) { 
+                // Line is potentially entering the clip region with respect to this edge.
+                // (e.g., for left edge, -dx < 0 means line goes from left to right, dx > 0).
+                // We want the largest t0 among all entry points.
+                if (r > t1) return null; // Line enters after it has already exited from another edge.
+                t0 = Math.max(t0, r);    // Update t0 to the latest entry point along the line.
+            } else { // p[i] > 0
+                // Line is potentially exiting the clip region with respect to this edge.
+                // (e.g., for left edge, -dx > 0 means line goes from right to left, dx < 0).
+                // We want the smallest t1 among all exit points.
+                if (r < t0) return null; // Line exits before it has entered from another edge.
+                t1 = Math.min(t1, r);    // Update t1 to the earliest exit point along the line.
+            }
+        }
     }
-}; 
+
+    // After checking all 4 edges:
+    // If t0 > t1, the line segment is completely outside the clipping window or is degenerate.
+    if (t0 > t1) return null; 
+
+    // Calculate the new clipped coordinates using parameters t0 and t1.
+    // (x1_clipped, y1_clipped) = (x1, y1) + t0 * (dx, dy)
+    // (x2_clipped, y2_clipped) = (x1, y1) + t1 * (dx, dy)
+    const clippedX1 = x1 + t0 * dx;
+    const clippedY1 = y1 + t0 * dy;
+    const clippedX2 = x1 + t1 * dx;
+    const clippedY2 = y1 + t1 * dy;
+
+    return { x1: clippedX1, y1: clippedY1, x2: clippedX2, y2: clippedY2 };
+}
+// Removed adjustLineForOverflow function

--- a/src/components/trendline.test.js
+++ b/src/components/trendline.test.js
@@ -1,24 +1,17 @@
-import { addFitter } from './trendline'; // Import the function to test
-import 'jest-canvas-mock'; // Ensures canvas context is mocked
+import { addFitter } from './trendline'; 
+import 'jest-canvas-mock'; 
 
-// Import the class to mock its constructor and methods
 import { LineFitter } from '../utils/lineFitter';
-// Import functions to spy on or mock their implementation
 import * as drawingUtils from '../utils/drawing';
 import * as labelUtils from './label';
 
-// Mocking dependencies
-jest.mock('../utils/lineFitter'); // Auto-mocks all exports, constructor will be jest.fn()
-
+jest.mock('../utils/lineFitter'); 
 jest.mock('../utils/drawing', () => ({
   drawTrendline: jest.fn(),
   fillBelowTrendline: jest.fn(),
   setLineStyle: jest.fn(),
 }));
-
-jest.mock('./label', () => ({
-  addTrendlineLabel: jest.fn(),
-}));
+jest.mock('./label', () => ({ addTrendlineLabel: jest.fn() }));
 
 describe('addFitter', () => {
     let mockCtx;
@@ -29,444 +22,257 @@ describe('addFitter', () => {
     let mockLineFitterInstance;
 
     beforeEach(() => {
-        // Reset all mocks before each test
         jest.clearAllMocks();
-
-        // Mock LineFitter instance and its methods
         mockLineFitterInstance = {
             add: jest.fn(),
-            f: jest.fn(x => x * 2 + 1), // Default mock implementation: y = 2x + 1
-            slope: jest.fn(() => 2),
+            f: jest.fn(x => x * 2 + 1), 
+            slope: jest.fn(() => 2),    
             intercept: jest.fn(() => 1),
-            fo: jest.fn(() => 50), // Default mock for projection
-            scale: jest.fn(() => 1), // Default mock for scale (positive)
-            minx: 10, // Default mock value
-            maxx: 100, // Default mock value
-            count: 0,
-            sumx: 0,
-            sumy: 0,
-            sumx2: 0,
-            sumxy: 0,
+            fo: jest.fn(() => 50), 
+            scale: jest.fn(() => 1), 
+            minx: undefined, 
+            maxx: undefined, 
+            count: 0,        
+            sumx: 0, sumy: 0, sumx2: 0, sumxy: 0,
         };
         LineFitter.mockImplementation(() => mockLineFitterInstance);
         
         mockCtx = {
-            save: jest.fn(),
-            translate: jest.fn(),
-            rotate: jest.fn(),
-            fillText: jest.fn(),
-            measureText: jest.fn(() => ({ width: 50 })),
-            font: '',
-            fillStyle: '',
-            strokeStyle: '',
-            lineWidth: 0,
-            beginPath: jest.fn(),
-            moveTo: jest.fn(),
-            lineTo: jest.fn(),
-            stroke: jest.fn(),
-            restore: jest.fn(),
+            save: jest.fn(), translate: jest.fn(), rotate: jest.fn(), fillText: jest.fn(),
+            measureText: jest.fn(() => ({ width: 50 })), font: '', fillStyle: '',
+            strokeStyle: '', lineWidth: 0, beginPath: jest.fn(), moveTo: jest.fn(),
+            lineTo: jest.fn(), stroke: jest.fn(), restore: jest.fn(),
         };
-
+        
         mockDatasetMeta = {
             controller: {
                 chart: {
-                    scales: {
-                        y: { getPixelForValue: jest.fn(val => val * 10) } // Default y-axis scale
-                    },
-                    options: {
-                        parsing: { xAxisKey: 'x', yAxisKey: 'y' }
-                    },
-                    chartArea: { bottom: 500, width: 800 },
+                    scales: { 'y': { getPixelForValue: jest.fn(val => val * 10), getValueForPixel: jest.fn(pixel => pixel / 10) } },
+                    options: { parsing: { xAxisKey: 'x', yAxisKey: 'y' } },
+                    chartArea: { top: 50, bottom: 450, left: 50, right: 750, width: 700, height: 400 },
                 }
             },
-            data: [ // Mocked datasetMeta.data to provide x,y values for start/endPos
-                { x: 10, y: 30 }, // Corresponds to data[0]
-                { x: 100, y: 210 } // Corresponds to data[data.length-1]
-            ]
+            data: [{x:0, y:0}] 
         };
-        
         mockXScale = {
-            getPixelForValue: jest.fn(val => val * 10), // Default x-axis scale
+            getPixelForValue: jest.fn(val => val * 10), 
+            getValueForPixel: jest.fn(pixel => pixel / 10), 
             options: { type: 'linear' }
         };
-        mockYScale = { // This is the fallback yScale if yAxisID is not found
-            getPixelForValue: jest.fn(val => val * 10) 
-        };
-
+        mockYScale = { getPixelForValue: jest.fn(val => val * 10), getValueForPixel: jest.fn(pixel => pixel / 10) };
+        
         mockDataset = {
-            data: [
-                { x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 } // Simple linear data
-            ],
-            yAxisID: 'y',
-            borderColor: 'blue',
-            borderWidth: 2,
+            data: [ { x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 } ], 
+            yAxisID: 'y', 
+            borderColor: 'blue', borderWidth: 2,
             trendlineLinear: {
-                colorMin: 'red',
-                colorMax: 'red',
-                width: 3,
-                lineStyle: 'dashed',
-                fillColor: false, // No fill by default
-                trendoffset: 0,   // No offset by default
-                projection: false,// No projection by default
-                xAxisKey: 'x',
-                yAxisKey: 'y',
-                label: {
-                    display: true,
-                    text: 'My Trend',
-                    color: 'black',
-                    offset: 5,
-                    displayValue: true,
-                    percentage: false,
-                    font: {
-                        family: 'Arial',
-                        size: 12,
-                    }
-                }
+                colorMin: 'red', colorMax: 'red', width: 3, lineStyle: 'dashed',
+                fillColor: false, trendoffset: 0, projection: false,
+                xAxisKey: 'x', yAxisKey: 'y',
+                label: { display: true, text: 'My Trend', color: 'black', offset: 5, displayValue: true, percentage: false, font: { family: 'Arial', size: 12 } }
             }
         };
     });
 
     test('Scenario 1: Simple linear data, no projection, no offset', () => {
-        // Arrange
-        // Use default mockDataset which has simple linear data
-        // fitter.f(10) = 2*10+1 = 21, fitter.f(100) = 2*100+1 = 201
-        // y1 = yScaleToUse.getPixelForValue(21) = 210
-        // y2 = yScaleToUse.getPixelForValue(201) = 2010
-        // x1 = datasetMeta.data[0].x = 10 (since startPos is datasetMeta.data[0].x)
-        // x2 = datasetMeta.data[lastIndex].x = 100 (since endPos is datasetMeta.data[mockDataset.data.length-1].x)
-        
-        // Override specific mock values for this test if needed
-        mockLineFitterInstance.minx = 10;
-        mockLineFitterInstance.maxx = 30; // Based on the data {x:10}, {x:20}, {x:30}
-        mockDatasetMeta.data = [ // Ensure datasetMeta.data aligns with dataset.data for start/endPos
-            { x: 10 }, { x: 20 }, { x: 30 }
-        ];
+        mockDatasetMeta.data = [{x:10, y:30}]; 
+        mockLineFitterInstance.minx = 10; 
+        mockLineFitterInstance.maxx = 30; 
+        mockLineFitterInstance.count = 3;
+        mockLineFitterInstance.f = jest.fn(x => {
+            if (x === 10) return 21; 
+            if (x === 30) return 61; 
+            return 2*x+1; 
+        });
         mockXScale.getPixelForValue = jest.fn(val => {
-            if (val === 10) return 100; // pixel for fitter.minx
-            if (val === 30) return 300; // pixel for fitter.maxx
-            return val * 10;
+            if (val === 10) return 100; 
+            if (val === 30) return 300; 
+            return val*10;
         });
         mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => {
-            if (val === mockLineFitterInstance.f(10)) return 210; // pixel for fitter.f(minx)
-            if (val === mockLineFitterInstance.f(30)) return 610; // pixel for fitter.f(maxx)
-            return val * 10;
+            if (val === 21) return 210; 
+            if (val === 61) return 610; 
+            return val*10;
         });
-
-
-        // Act
-        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(mockDataset.data.length);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(20, 50);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(30, 70);
-
-        // Verify how pixel coordinates are determined
-        // startPos will be datasetMeta.data[0].x = 10, endPos will be datasetMeta.data[2].x = 30
-        // So, x1 and x2 will be these values directly, not from xScale.getPixelForValue(fitter.minx/maxx)
-        // y1 and y2 will be yScale.getPixelForValue(fitter.f(fitter.minx/maxx))
-        const expectedX1 = 10; // Directly from datasetMeta.data[0].x
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(mockLineFitterInstance.f(mockLineFitterInstance.minx));
-        const expectedX2 = 30; // Directly from datasetMeta.data[2].x
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(mockLineFitterInstance.f(mockLineFitterInstance.maxx));
         
-        expect(drawingUtils.setLineStyle).toHaveBeenCalledWith(mockCtx, mockDataset.trendlineLinear.lineStyle);
-        expect(mockCtx.lineWidth).toBe(mockDataset.trendlineLinear.width);
-
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith({
-            ctx: mockCtx,
-            x1: expectedX1,
-            y1: expectedY1,
-            x2: expectedX2,
-            y2: expectedY2,
-            colorMin: mockDataset.trendlineLinear.colorMin,
-            colorMax: mockDataset.trendlineLinear.colorMax,
-        });
-
-        expect(labelUtils.addTrendlineLabel).toHaveBeenCalledTimes(1); // Assuming label.display is true
-        expect(drawingUtils.fillBelowTrendline).not.toHaveBeenCalled(); // fillColor is false by default
-    });
-
-    test('Scenario 2: Data with null or undefined values', () => {
-        // Arrange
-        mockDataset.data = [
-            { x: 10, y: 30 },
-            null, // Null data point
-            { x: 20, y: 50 },
-            undefined, // Undefined data point
-            { x: 30, y: 70 }
-        ];
-        mockLineFitterInstance.minx = 10;
-        mockLineFitterInstance.maxx = 30;
-         mockDatasetMeta.data = [ // Ensure datasetMeta.data aligns with dataset.data for start/endPos
-            { x: 10 }, null, { x: 20 }, undefined, { x: 30 }
-        ];
-        // Adjust y-scale mock for potentially different fitter values if nulls changed calculation
-        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => val * 10);
-
-
-        // Act
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        // fitter.add should only be called for valid data points
+        
         expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(3);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(20, 50);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(30, 70);
-        // Other assertions (drawing, styling, label) would follow similarly
-        expect(drawingUtils.setLineStyle).toHaveBeenCalledTimes(1);
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledTimes(1);
+        // Expecting clipped coordinates based on previous log analysis {"x1":100,"y1":210,"x2":220,"y2":450}
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 100, y1: 210, x2: 220, y2: 450 }));
         expect(labelUtils.addTrendlineLabel).toHaveBeenCalledTimes(1);
     });
 
-    test('Scenario 3: trendlineLinear.projection is true and fitter.scale() < 0', () => {
-        // Arrange
-        mockDataset.trendlineLinear.projection = true;
-        mockLineFitterInstance.scale = jest.fn(() => -1); // scale() < 0
-        mockLineFitterInstance.fo = jest.fn(() => 40); // Projected x-value
-        mockLineFitterInstance.minx = 10;
-        mockLineFitterInstance.maxx = 30; // Original maxx before projection
+    test('Scenario 2: Data with null or undefined values', () => {
+        mockDataset.data = [ { x: 10, y: 30 }, null, { x: 20, y: 50 }, undefined, { x: 30, y: 70 } ];
+        mockDatasetMeta.data = [{x:10, y:30}]; 
+        mockLineFitterInstance.minx = 10; 
+        mockLineFitterInstance.maxx = 30;
+        mockLineFitterInstance.count = 3; 
+        mockLineFitterInstance.f = jest.fn(x => (x === 10 ? 21 : (x === 30 ? 61 : 2 * x + 1)));
+        mockXScale.getPixelForValue = jest.fn(val => (val === 10 ? 100 : (val === 30 ? 300 : val*10) ));
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => (val === 21 ? 210 : (val === 61 ? 610 : val*10)));
         
-        mockDatasetMeta.data = [{ x: 10 }, { x: 20 }, { x: 30 }];
-        const yAtMinX = mockLineFitterInstance.f(mockLineFitterInstance.minx); // e.g. 2*10+1 = 21
-        const yAtFo = mockLineFitterInstance.f(mockLineFitterInstance.fo());   // e.g. 2*40+1 = 81
+        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(3);
+        // Expecting clipped coordinates as per Scenario 1, since data and chartArea are similar enough
+        // for the same clipping to occur on the unclipped (100,210)-(300,610) line.
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 100, y1: 210, x2: 220, y2: 450 }));
+        expect(labelUtils.addTrendlineLabel).toHaveBeenCalledTimes(1);
+    });
 
+    test('Scenario 3: trendlineLinear.projection is true', () => {
+        mockDataset.trendlineLinear.projection = true;
+        mockDatasetMeta.data = [{x:10, y:30}]; 
+        mockLineFitterInstance.count = 3; 
+        mockLineFitterInstance.slope = jest.fn(() => 2); 
+        mockLineFitterInstance.intercept = jest.fn(() => 1); 
+        mockLineFitterInstance.f = jest.fn(x => mockLineFitterInstance.slope() * x + mockLineFitterInstance.intercept());
+        
+        // Expected data values for intersections based on y=2x+1 and chartArea {t:50,b:450,l:50,r:750}, scales val = px/10
+        // For the filter in trendline.js: actualChartMinY = 5, actualChartMaxY = 45.
+        // Valid intersection points (data values): (5,11) and (22,45)
         mockXScale.getPixelForValue = jest.fn(val => {
-            if (val === mockLineFitterInstance.fo()) return 400; // Pixel for projected x
-            return val * 10; // Fallback for minx
+            if (val === 5) return 50;   
+            if (val === 22) return 220; 
+            return NaN; 
         });
         mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => {
-            if (val === yAtMinX) return 210;
-            if (val === yAtFo) return 810;
-            return val * 10;
+            if (val === 11) return 110; 
+            if (val === 45) return 450; 
+            return NaN; 
         });
-        
-        // Act
+        mockXScale.getValueForPixel = jest.fn(pixel => {
+            if (pixel === mockDatasetMeta.controller.chart.chartArea.left) return 5; 
+            if (pixel === mockDatasetMeta.controller.chart.chartArea.right) return 75; 
+            return NaN;
+        });
+        // This mock ensures that chartMinY/MaxY are correctly ordered for the filter
+        // based on the corrected logic in trendline.js (Math.min/max of top/bottom data values)
+        mockDatasetMeta.controller.chart.scales.y.getValueForPixel = jest.fn(pixel => {
+            if (pixel === mockDatasetMeta.controller.chart.chartArea.top) return 5; 
+            if (pixel === mockDatasetMeta.controller.chart.chartArea.bottom) return 45; 
+            return NaN;
+        });
+
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        expect(mockLineFitterInstance.scale).toHaveBeenCalled();
-        expect(mockLineFitterInstance.fo).toHaveBeenCalled();
-
-        const expectedX1 = 10; // datasetMeta.data[0].x
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtMinX);
-        // x2 is now xScale.getPixelForValue(fitter.fo()) because projection is active
-        const expectedX2 = mockXScale.getPixelForValue(mockLineFitterInstance.fo());
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtFo);
-
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({
-            x1: expectedX1,
-            y1: expectedY1,
-            x2: expectedX2,
-            y2: expectedY2,
-        }));
+        
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 50, y1: 110, x2: 220, y2: 450 }));
     });
     
-    test('Scenario 3b: trendlineLinear.projection is true, fitter.scale() < 0, AND fo() < minx', () => {
-        // Arrange
+    test('Scenario 3b: trendlineLinear.projection is true (negative slope)', () => {
         mockDataset.trendlineLinear.projection = true;
-        mockLineFitterInstance.scale = jest.fn(() => -1); // scale() < 0
-        mockLineFitterInstance.minx = 10;
-        mockLineFitterInstance.maxx = 30;
-        mockLineFitterInstance.fo = jest.fn(() => 5); // Projected x-value IS LESS THAN minx
-
-        mockDatasetMeta.data = [{ x: 10 }, { x: 20 }, { x: 30 }];
-        const yAtMinX = mockLineFitterInstance.f(mockLineFitterInstance.minx);
-        const yAtMaxX = mockLineFitterInstance.f(mockLineFitterInstance.maxx); // Should use f(maxx) as x2val becomes maxx
-
+        mockDatasetMeta.data = [{x:10, y:30}]; 
+        mockLineFitterInstance.count = 3; 
+        mockLineFitterInstance.slope = jest.fn(() => -2); 
+        mockLineFitterInstance.intercept = jest.fn(() => 100); 
+        mockLineFitterInstance.f = jest.fn(x => mockLineFitterInstance.slope() * x + mockLineFitterInstance.intercept());
+        
+        // Expected data values for intersections based on y=-2x+100
+        // For the filter in trendline.js: actualChartMinY = 5, actualChartMaxY = 45.
+        // Valid intersection points (data values): (27.5,45) and (47.5,5)
         mockXScale.getPixelForValue = jest.fn(val => {
-            if (val === mockLineFitterInstance.minx) return 100;
-            if (val === mockLineFitterInstance.maxx) return 300; // Pixel for fitter.maxx (used due to fo < minx)
-            return val * 10;
+            if (val === 27.5) return 275;
+            if (val === 47.5) return 475;
+            return NaN;
         });
-         mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => {
-            if (val === yAtMinX) return 210;
-            if (val === yAtMaxX) return 610; // Pixel for y at maxx
-            return val * 10;
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => {
+            if (val === 45) return 450;
+            if (val === 5) return 50;
+            return NaN;
         });
-
-        // Act
+        mockXScale.getValueForPixel = jest.fn(pixel => (pixel === 50 ? 5 : (pixel === 750 ? 75 : NaN)));
+        mockDatasetMeta.controller.chart.scales.y.getValueForPixel = jest.fn(pixel => (pixel === 50 ? 5 : (pixel === 450 ? 45 : NaN)));
+        
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        expect(mockLineFitterInstance.scale).toHaveBeenCalled();
-        expect(mockLineFitterInstance.fo).toHaveBeenCalled();
-
-        // x1 is datasetMeta.data[0].x
-        // x2 is xScale.getPixelForValue(fitter.maxx) because fo() < minx lead to x2value = fitter.maxx
-        const expectedX1 = 10;
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtMinX);
-        const expectedX2 = mockXScale.getPixelForValue(mockLineFitterInstance.maxx);
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtMaxX);
-
-
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({
-            x1: expectedX1,
-            y1: expectedY1,
-            x2: expectedX2,
-            y2: expectedY2,
-        }));
+        
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 275, y1: 450, x2: 475, y2: 50 }));
     });
 
-
     test('Scenario 4: trendoffset (positive)', () => {
-        // Arrange
-        mockDataset.trendlineLinear.trendoffset = 1; // Skip the first data point
-        mockDataset.data = [{ x: 5, y: 10 }, { x: 10, y: 30 }, { x: 20, y: 50 }];
-        // firstIndex will be 1 + 0 = 1. So, data processing starts from dataset.data[1]
-        // datasetMeta.data should reflect this for startPos calculation.
-        // startPos will be datasetMeta.data[1].x
-        mockDatasetMeta.data = [{x:5}, {x:10}, {x:20}]; // Original meta data
-        
-        mockLineFitterInstance.minx = 10; // Fitter sees {x:10}, {x:20}
+        mockDataset.trendlineLinear.trendoffset = 1; 
+        mockDataset.data = [{ x: 5, y: 10 }, { x: 10, y: 30 }, { x: 20, y: 50 }]; 
+        mockDatasetMeta.data = [{x:5, y:10}]; 
+        mockLineFitterInstance.minx = 10; 
         mockLineFitterInstance.maxx = 20;
+        mockLineFitterInstance.count = 2; 
+        mockLineFitterInstance.f = jest.fn(x => (x === 10 ? 21 : (x === 20 ? 41 : NaN)));
+        mockXScale.getPixelForValue = jest.fn(val => (val === 10 ? 100 : (val === 20 ? 200 : NaN)));
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => (val === 21 ? 210 : (val === 41 ? 410 : NaN)));
         
-        const yAtFitterMinX = mockLineFitterInstance.f(mockLineFitterInstance.minx); // f(10)
-        const yAtFitterMaxX = mockLineFitterInstance.f(mockLineFitterInstance.maxx); // f(20)
-
-        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => val*10);
-
-
-        // Act
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        // fitter.add should be called for data from index 1 onwards
+        
         expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(2);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30); // From dataset.data[1]
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(20, 50); // From dataset.data[2]
-        expect(mockLineFitterInstance.add).not.toHaveBeenCalledWith(5, 10);
-
-        // startPos = datasetMeta.data[1].x = 10
-        // endPos = datasetMeta.data[2].x = 20
-        const expectedX1 = 10; 
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtFitterMinX);
-        const expectedX2 = 20;
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtFitterMaxX);
-
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({
-            x1: expectedX1,
-            y1: expectedY1,
-            x2: expectedX2,
-            y2: expectedY2,
-        }));
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 100, y1: 210, x2: 200, y2: 410 }));
     });
 
     test('Scenario 5: trendoffset (negative)', () => {
-        // Arrange
-        mockDataset.trendlineLinear.trendoffset = -1; // Skip the last data point effectively for fitter
-        mockDataset.data = [{ x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 }];
-        // firstIndex will be (dataset.data.length) + (-1) = 3 - 1 = 2.
-        // The loop for fitter.add will consider index < dataset.data.length + trendoffset (i.e. index < 2)
-        // So, data points at index 0 and 1 are added.
-        // datasetMeta.data for startPos (firstIndex is 2, so it's datasetMeta.data[2].x)
-        // However, the internal loop `dataset.data.forEach` has `if (trendoffset < 0 && index < dataset.data.length + trendoffset) return;`
-        // This means for trendoffset = -1, if index < 2, it returns. This seems to be an error in my understanding or the code.
-        // Let's re-evaluate:
-        // firstIndex = (negative_offset_is_less_than_zero ? dataset.data.length : 0) + trendoffset + ...
-        // firstIndex = dataset.data.length + trendoffset = 3 + (-1) = 2. This is where findIndex starts.
-        // The findIndex will likely return 0 if dataset.data[2] is valid. So firstIndex becomes 2.
-        // startPos = datasetMeta.data[2].x
-        // The loop: `if (trendoffset < 0 && index < dataset.data.length + trendoffset) return;`
-        // `index < 3 + (-1)` => `index < 2`. So for index 0 and 1, it will *return* (skip add). This means only data[2] is added.
-
-        mockDatasetMeta.data = [{x:10}, {x:20}, {x:30}];
-        mockLineFitterInstance.minx = 30; // Fitter effectively sees only {x:30, y:70}
-        mockLineFitterInstance.maxx = 30;
-        const yAtFitterMinX = mockLineFitterInstance.f(mockLineFitterInstance.minx);
-        const yAtFitterMaxX = mockLineFitterInstance.f(mockLineFitterInstance.maxx);
-        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => val*10);
-
-
-        // Act
-        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        // Due to the condition `if (trendoffset < 0 && index < dataset.data.length + trendoffset) return;`
-        // index 0 (0 < 2 is true, returns)
-        // index 1 (1 < 2 is true, returns)
-        // index 2 (2 < 2 is false, proceeds)
-        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(1);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(30, 70); // Only last point based on logic
+        mockDataset.trendlineLinear.trendoffset = -1; 
+        mockDataset.data = [{ x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 }]; 
+        mockDatasetMeta.data = [{x:10, y:30}]; 
+        mockLineFitterInstance.minx = 10; 
+        mockLineFitterInstance.maxx = 20;
+        mockLineFitterInstance.count = 2; 
+        mockLineFitterInstance.f = jest.fn(x => (x === 10 ? 21 : (x === 20 ? 41 : NaN)));
+        mockXScale.getPixelForValue = jest.fn(val => (val === 10 ? 100 : (val === 20 ? 200 : NaN)));
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => (val === 21 ? 210 : (val === 41 ? 410 : NaN)));
         
-        // startPos = datasetMeta.data[firstIndex (which is 2)].x = 30
-        // endPos = datasetMeta.data[lastIndex (which is 2)].x = 30
-        const expectedX1 = 30;
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtFitterMinX);
-        const expectedX2 = 30;
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtFitterMaxX);
-
-        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({
-            x1: expectedX1,
-            y1: expectedY1,
-            x2: expectedX2,
-            y2: expectedY2,
-        }));
+        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(2);
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 100, y1: 210, x2: 200, y2: 410 }));
     });
     
-    test('Scenario 5b: trendoffset (negative) where it makes firstIndex search start beyond array bounds', () => {
-        // Arrange
-        mockDataset.trendlineLinear.trendoffset = -3; // Equal to data length
-        mockDataset.data = [{ x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 }];
-        // firstIndex calculation: `dataset.data.length + trendoffset` = 3 + (-3) = 0.
-        // `dataset.data.slice(trendoffset)` becomes `dataset.data.slice(-3)` which is the whole array.
-        // `findIndex` on this slice, starting from `firstIndex` (0) should find the first valid point at index 0.
-        // So `firstIndex` becomes 0.
-        // `startPos` = `datasetMeta.data[0].x`.
-        // Loop for fitter.add: `if (trendoffset < 0 && index < dataset.data.length + trendoffset) return;`
-        // `index < 3 + (-3)` => `index < 0`. This condition is never met. So all points should be added.
-        // This indicates the `trendoffset` logic might be complex. The initial `if (Math.abs(trendoffset) >= dataset.data.length) trendoffset = 0;`
-        // should handle this. So trendoffset becomes 0.
+    test('Scenario 5b: trendoffset (negative) to exclude all but one point', () => {
+        mockDataset.trendlineLinear.trendoffset = -2; 
+        mockDataset.data = [{ x: 0, y: 0 }, { x: 1, y: 1 }, { x: 2, y: 2 }]; 
+        mockDatasetMeta.data = [{x:0, y:0}];
+        mockLineFitterInstance.minx = 0;
+        mockLineFitterInstance.maxx = 0;
+        mockLineFitterInstance.count = 1; 
 
-        // Act
-        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale); // trendoffset should become 0
-
-        // Assert
-        expect(LineFitter).toHaveBeenCalledTimes(1);
-        // All points should be added because trendoffset was reset to 0
-        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(3); 
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(20, 50);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(30, 70);
+        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(1);
+        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(0,0);
+        expect(drawingUtils.drawTrendline).not.toHaveBeenCalled(); 
+        expect(labelUtils.addTrendlineLabel).not.toHaveBeenCalled(); 
     });
 
+    test('Scenario 5c: trendoffset (negative) where it makes firstIndex search start beyond array bounds', () => {
+        mockDataset.trendlineLinear.trendoffset = -3; 
+        mockDataset.data = [{ x: 10, y: 30 }, { x: 20, y: 50 }, { x: 30, y: 70 }]; 
+        mockDatasetMeta.data = [{x:10, y:30}];
+        mockLineFitterInstance.count = 3; 
+        mockLineFitterInstance.minx = 10; 
+        mockLineFitterInstance.maxx = 30; 
+        mockLineFitterInstance.f = jest.fn(x => (x === 10 ? 21 : (x === 30 ? 61 : NaN))); 
+        mockXScale.getPixelForValue = jest.fn(val => (val === 10 ? 100 : (val === 30 ? 300 : NaN)));
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => (val === 21 ? 210 : (val === 61 ? 610 : NaN)));
+        
+        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale); 
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(3); 
+        // Expect clipped coordinates based on Scenario 1's log output
+        expect(drawingUtils.drawTrendline).toHaveBeenCalledWith(expect.objectContaining({ x1: 100, y1: 210, x2: 220, y2: 450 }));
+    });
 
     test('Scenario 6: fillColor is true', () => {
-        // Arrange
         mockDataset.trendlineLinear.fillColor = 'rgba(0,0,255,0.1)';
-        mockLineFitterInstance.minx = 10;
+        mockDatasetMeta.data = [{x:10, y:30}];
+        mockLineFitterInstance.minx = 10; 
         mockLineFitterInstance.maxx = 30;
-        mockDatasetMeta.data = [{ x: 10 }, { x: 20 }, { x: 30 }];
-        const yAtMinX = mockLineFitterInstance.f(mockLineFitterInstance.minx);
-        const yAtMaxX = mockLineFitterInstance.f(mockLineFitterInstance.maxx);
-
-        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => val*10);
-
-
-        // Act
-        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        // Assert
-        expect(drawingUtils.fillBelowTrendline).toHaveBeenCalledTimes(1);
-        const expectedX1 = 10; // datasetMeta.data[0].x
-        const expectedY1 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtMinX);
-        const expectedX2 = 30; // datasetMeta.data[2].x
-        const expectedY2 = mockDatasetMeta.controller.chart.scales.y.getPixelForValue(yAtMaxX);
+        mockLineFitterInstance.count = 3; 
+        mockLineFitterInstance.f = jest.fn(x => (x === 10 ? 21 : (x === 30 ? 61 : NaN)));
+        mockXScale.getPixelForValue = jest.fn(val => (val === 10 ? 100 : (val === 30 ? 300 : NaN)));
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => (val === 21 ? 210 : (val === 61 ? 610 : NaN)));
         
+        addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
+        
+        expect(drawingUtils.fillBelowTrendline).toHaveBeenCalledTimes(1);
+        // Expect clipped coordinates based on Scenario 1's log output
         expect(drawingUtils.fillBelowTrendline).toHaveBeenCalledWith(
-            mockCtx,
-            expectedX1,
-            expectedY1,
-            expectedX2,
-            expectedY2,
+            mockCtx, 100, 210, 220, 450, 
             mockDatasetMeta.controller.chart.chartArea.bottom,
             mockDataset.trendlineLinear.fillColor
         );
@@ -476,67 +282,75 @@ describe('addFitter', () => {
         mockXScale.options.type = 'timeseries';
         const date1 = new Date('2023-01-01T00:00:00.000Z');
         const date2 = new Date('2023-01-02T00:00:00.000Z');
-        mockDataset.data = [
-            { x: date1.toISOString(), y: 10 }, // Using xAxisKey 'x'
-            { t: date2.toISOString(), y: 20 }  // Using fallback 't'
-        ];
-        mockDataset.trendlineLinear.xAxisKey = 'x'; // or 't' if that's the primary
+        const date1Str = date1.toISOString();
+        const date2Str = date2.toISOString();
+        mockDataset.data = [ { x: date1Str, y: 10 }, { t: date2Str, y: 20 } ]; 
+        mockDataset.trendlineLinear.xAxisKey = 'x'; 
+        mockDatasetMeta.data = [{ x: date1Str, y: 10 }]; 
         
-        mockLineFitterInstance.minx = date1.getTime();
-        mockLineFitterInstance.maxx = date2.getTime();
-        mockDatasetMeta.data = [{ x: date1.toISOString() }, { t: date2.toISOString() }];
-        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => val*10);
-
+        const date1Ts = date1.getTime();
+        const date2Ts = date2.getTime();
+        mockLineFitterInstance.minx = date1Ts;
+        mockLineFitterInstance.maxx = date2Ts;
+        mockLineFitterInstance.count = 2; 
+        mockLineFitterInstance.f = jest.fn(t => {
+            if (t === date1Ts) return 1.0; 
+            if (t === date2Ts) return 2.0; 
+            return NaN;
+        }); 
+        mockXScale.getPixelForValue = jest.fn(t => {
+            if (t === date1Ts) return 50; 
+            if (t === date2Ts) return 150; 
+            return NaN;
+        });
+        mockDatasetMeta.controller.chart.scales.y.getPixelForValue = jest.fn(val => {
+            if (val === 1.0) return 10; 
+            if (val === 2.0) return 20; 
+            return NaN;
+        });
 
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(2); 
         expect(mockLineFitterInstance.add).toHaveBeenCalledWith(date1.getTime(), 10);
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(date2.getTime(), 20);
+        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(date2.getTime(), 20); 
+        // The line (50,10) to (150,20) is outside chartArea.top=50, so it should be clipped out.
+        expect(drawingUtils.drawTrendline).not.toHaveBeenCalled(); 
     });
     
     test('Handles data where x or y might be missing for object-type data but not timeseries', () => {
-        mockXScale.options.type = 'linear'; // Not time/timeseries
-        mockDataset.data = [
-            { x: 10, y: 30 },
-            { x: 20 },        // y is missing
-            { y: 70 },        // x is missing (should use index)
-            { value: 90 }     // x and y are missing (should use index and value for y)
-        ];
-        // datasetMeta.data would correspond to these for start/endPos
-        mockDatasetMeta.data = [{x:10, y:30}, {x:20}, {y:70}, {value:90}];
-        mockLineFitterInstance.minx = 0; // Will use index for some
-        mockLineFitterInstance.maxx = 3;
-
-
+        mockXScale.options.type = 'linear'; 
+        mockDataset.data = [ { x: 10, y: 30 }, { x: 20 }, { y: 70 }, { value: 90 } ];
+        mockDatasetMeta.data = mockDataset.data; 
+        mockLineFitterInstance.count = 1; 
+        mockLineFitterInstance.minx = 10; 
+        mockLineFitterInstance.maxx = 10; 
+        
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
-
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30); // Index 0
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(1, 20);  // Index 1, data.x
-        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(2, 70);  // Index 2, data.y
-        // The fourth data point {value: 90} is tricky. The code is:
-        // } else if (xy) { // xy is true if typeof dataset.data[firstIndex] === 'object'
-        //     if (!isNaN(data.x) && !isNaN(data.y)) { fitter.add(data.x, data.y); } 
-        //     else if (!isNaN(data.x)) { fitter.add(index, data.x); }  <-- This would be for {x: val}
-        //     else if (!isNaN(data.y)) { fitter.add(index, data.y); }  <-- This would be for {y: val}
-        // } else { fitter.add(index, data); }
-        // If data = {value: 90}, xy is true. data.x is NaN, data.y is NaN. So it doesn't call fitter.add for this one.
-        // This should be tested to confirm.
-        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(3);
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(1);
+        expect(mockLineFitterInstance.add).toHaveBeenCalledWith(10, 30);
+        expect(drawingUtils.setLineStyle).not.toHaveBeenCalled(); 
+        expect(drawingUtils.drawTrendline).not.toHaveBeenCalled();
+        expect(labelUtils.addTrendlineLabel).not.toHaveBeenCalled();
     });
-
 
     test('Uses parsingOptions for xAxisKey and yAxisKey if specific ones are not provided', () => {
         delete mockDataset.trendlineLinear.xAxisKey;
         delete mockDataset.trendlineLinear.yAxisKey;
         mockDatasetMeta.controller.chart.options.parsing = { xAxisKey: 'customX', yAxisKey: 'customY' };
-        mockDataset.data = [{ customX: 5, customY: 15 }];
-        mockDatasetMeta.data = [{customX: 5}]; // For start/end pos
-        
+        mockDataset.data = [{ customX: 5, customY: 15 }]; 
+        mockDatasetMeta.data = [{customX: 5}]; 
+        mockLineFitterInstance.count = 1; 
         mockLineFitterInstance.minx = 5;
         mockLineFitterInstance.maxx = 5;
 
         addFitter(mockDatasetMeta, mockCtx, mockDataset, mockXScale, mockYScale);
+        
+        expect(mockLineFitterInstance.add).toHaveBeenCalledTimes(1); 
         expect(mockLineFitterInstance.add).toHaveBeenCalledWith(5, 15);
+        expect(drawingUtils.setLineStyle).not.toHaveBeenCalled(); 
+        expect(drawingUtils.drawTrendline).not.toHaveBeenCalled();
+        expect(labelUtils.addTrendlineLabel).not.toHaveBeenCalled();
     });
-
 });


### PR DESCRIPTION
This commit addresses several issues with the chartjs-plugin-trendline:

1.  **Trendline Boundaries and Projection:**
    *   Trendlines now correctly extend to the chart boundaries when projected.
    *   Non-projected trendlines are drawn between the min/max x-values of the fitted data.
    *   Implemented the Liang-Barsky line clipping algorithm to ensure all trendlines are precisely clipped to the chart's drawable area, preventing overflow.
    *   Removed the previous `adjustLineForOverflow` function.

2.  **Consistent Slope/Intercept:**
    *   Ensured that enabling or disabling projection does not change the trendline's fundamental slope or intercept. The projection is purely a visual extension of the line calculated by `LineFitter`.

3.  **Data Point Accuracy for Fitting:**
    *   Corrected the logic for `trendoffset`:
        *   Positive `trendoffset` correctly skips points from the beginning of the dataset.
        *   Negative `trendoffset` now correctly excludes points from the *end* of the dataset.
    *   Improved handling of object data (e.g., `{x, y}` pairs): points are now skipped if *either* the x or y coordinate is invalid (null, undefined, NaN), preventing the use of `index` as a fallback coordinate which could skew the trendline.

4.  **Code Clarity and Examples:**
    *   Added comprehensive comments to `src/components/trendline.js` to explain the new logic for boundary calculations, clipping, and data selection.
    *   Updated `example/lineChartProjection.html` with multiple datasets and an "Observations Guide" to clearly demonstrate the corrected behaviors and new features like `trendoffset` and null data point handling.

These changes collectively improve the accuracy, visual correctness, and predictability of the trendlines generated by the plugin.