### PR TITLE
refactor: replace 11 individual params with options object in addTrendlineLabel

### DIFF
--- a/SIMPLIFY_PLAN.md
+++ b/SIMPLIFY_PLAN.md
@@ -4,7 +4,7 @@ Varje cron-run plockar nästa ocheckade punkt, gör en refactoring-branch med ti
 
 ## Kö
 
-- [ ] **refactor/label-to-options** — `label.js`: ersätt 11 individuella parametrar med ett options-objekt. Uppdatera `addTrendlineLabel`-signaturen och alla anrop.
+- [x] **refactor/label-to-options** — `label.js`: ersätt 11 individuella parametrar med ett options-objekt. Uppdatera `addTrendlineLabel`-signaturen och alla anrop.
 - [ ] **refactor/drawing-shared-validation** — `drawing.js`: extrahera `validateFiniteCoords` helper från `drawTrendline` och `fillBelowTrendline` för att eliminera duplicerad sanity-check-kod.
 - [ ] **refactor/plugin-legend-cleanup** — `plugin.js`: förenkla `beforeInit` legend-logiken. Extract:a legend-item-skapande till en egen funktion.
 - [ ] **refactor/trendline-data-extraction** — `trendline.js`: bryt ut datainsamlingslogiken (forEach-loopen) ur `addFitter` till en egen `collectDataPoints`-funktion.

--- a/src/components/label.js
+++ b/src/components/label.js
@@ -1,30 +1,28 @@
 /**
  * Adds a label to the trendline at the calculated angle.
  * @param {CanvasRenderingContext2D} ctx - The canvas rendering context.
- * @param {string} label - The label text to add.
- * @param {number} x1 - The starting x-coordinate of the trendline.
- * @param {number} y1 - The starting y-coordinate of the trendline.
- * @param {number} x2 - The ending x-coordinate of the trendline.
- * @param {number} y2 - The ending y-coordinate of the trendline.
- * @param {number} angle - The angle (in radians) of the trendline.
- * @param {string} labelColor - The color of the label text.
- * @param {string} family - The font family for the label text.
- * @param {number} size - The font size for the label text.
- * @param {number} offset - The offset of the label from the trendline
+ * @param {Object} options - Configuration options for the label.
+ * @param {string} options.label - The label text to add.
+ * @param {number} options.x1 - The starting x-coordinate of the trendline.
+ * @param {number} options.y1 - The starting y-coordinate of the trendline.
+ * @param {number} options.x2 - The ending x-coordinate of the trendline.
+ * @param {number} options.y2 - The ending y-coordinate of the trendline.
+ * @param {number} options.angle - The angle (in radians) of the trendline.
+ * @param {string} options.labelColor - The color of the label text.
+ * @param {string} options.family - The font family for the label text.
+ * @param {number} options.size - The font size for the label text.
+ * @param {number} options.offset - The offset of the label from the trendline.
  */
-export const addTrendlineLabel = (
-    ctx,
-    label,
-    x1,
-    y1,
-    x2,
-    y2,
-    angle,
-    labelColor,
-    family,
-    size,
-    offset
-) => {
+export const addTrendlineLabel = (ctx, options) => {
+    const {
+        label,
+        x1, y1, x2, y2,
+        angle,
+        labelColor,
+        family,
+        size,
+        offset,
+    } = options;
     // Set the label font and color
     ctx.font = `${size}px ${family}`;
     ctx.fillStyle = labelColor;

--- a/src/components/label.test.js
+++ b/src/components/label.test.js
@@ -32,16 +32,15 @@ describe('addTrendlineLabel', () => {
 
 
     test('should correctly set label text and style', () => {
-        addTrendlineLabel(
-            mockCtx,
-            mockLabel,
-            mockX1, mockY1, mockX2, mockY2,
-            mockAngle,
-            mockLabelColor,
-            mockFamily,
-            mockSize,
-            mockOffset
-        );
+        addTrendlineLabel(mockCtx, {
+            label: mockLabel,
+            x1: mockX1, y1: mockY1, x2: mockX2, y2: mockY2,
+            angle: mockAngle,
+            labelColor: mockLabelColor,
+            family: mockFamily,
+            size: mockSize,
+            offset: mockOffset,
+        });
 
         expect(mockCtx.fillText).toHaveBeenCalledWith(mockLabel, expect.any(Number), expect.any(Number));
         expect(mockCtx.measureText).toHaveBeenCalledWith(mockLabel);
@@ -50,16 +49,15 @@ describe('addTrendlineLabel', () => {
     });
 
     test('should correctly apply transformations and positioning', () => {
-        addTrendlineLabel(
-            mockCtx,
-            mockLabel,
-            mockX1, mockY1, mockX2, mockY2,
-            mockAngle,
-            mockLabelColor,
-            mockFamily,
-            mockSize,
-            mockOffset
-        );
+        addTrendlineLabel(mockCtx, {
+            label: mockLabel,
+            x1: mockX1, y1: mockY1, x2: mockX2, y2: mockY2,
+            angle: mockAngle,
+            labelColor: mockLabelColor,
+            family: mockFamily,
+            size: mockSize,
+            offset: mockOffset,
+        });
 
         const midX = (mockX1 + mockX2) / 2;
         const midY = (mockY1 + mockY2) / 2;
@@ -74,16 +72,15 @@ describe('addTrendlineLabel', () => {
     });
 
     test('should save and restore canvas state', () => {
-        addTrendlineLabel(
-            mockCtx,
-            mockLabel,
-            mockX1, mockY1, mockX2, mockY2,
-            mockAngle,
-            mockLabelColor,
-            mockFamily,
-            mockSize,
-            mockOffset
-        );
+        addTrendlineLabel(mockCtx, {
+            label: mockLabel,
+            x1: mockX1, y1: mockY1, x2: mockX2, y2: mockY2,
+            angle: mockAngle,
+            labelColor: mockLabelColor,
+            family: mockFamily,
+            size: mockSize,
+            offset: mockOffset,
+        });
 
         expect(mockCtx.save).toHaveBeenCalledTimes(1);
         expect(mockCtx.restore).toHaveBeenCalledTimes(1);
@@ -95,17 +92,16 @@ describe('addTrendlineLabel', () => {
 
     test('should handle zero offset correctly', () => {
         const currentOffset = 0;
-        addTrendlineLabel(
-            mockCtx,
-            mockLabel,
-            mockX1, mockY1, mockX2, mockY2,
-            mockAngle,
-            mockLabelColor,
-            mockFamily,
-            mockSize,
-            currentOffset // Using zero offset
-        );
-        
+        addTrendlineLabel(mockCtx, {
+            label: mockLabel,
+            x1: mockX1, y1: mockY1, x2: mockX2, y2: mockY2,
+            angle: mockAngle,
+            labelColor: mockLabelColor,
+            family: mockFamily,
+            size: mockSize,
+            offset: currentOffset,
+        });
+
         const labelWidth = mockCtx.measureText(mockLabel).width;
         const adjustedX = -labelWidth / 2;
         const adjustedY = currentOffset; // y is the offset itself
@@ -114,16 +110,15 @@ describe('addTrendlineLabel', () => {
 
     test('should handle different angle correctly', () => {
         const currentAngle = Math.PI / 2; // 90 degrees
-        addTrendlineLabel(
-            mockCtx,
-            mockLabel,
-            mockX1, mockY1, mockX2, mockY2,
-            currentAngle, // Using different angle
-            mockLabelColor,
-            mockFamily,
-            mockSize,
-            mockOffset
-        );
+        addTrendlineLabel(mockCtx, {
+            label: mockLabel,
+            x1: mockX1, y1: mockY1, x2: mockX2, y2: mockY2,
+            angle: currentAngle,
+            labelColor: mockLabelColor,
+            family: mockFamily,
+            size: mockSize,
+            offset: mockOffset,
+        });
         expect(mockCtx.rotate).toHaveBeenCalledWith(currentAngle);
     });
 });

--- a/src/components/trendline.js
+++ b/src/components/trendline.js
@@ -282,19 +282,18 @@ export const addFitter = (datasetMeta, ctx, dataset, xScale, yScale) => {
                         })`;
                     }
                 }
-                addTrendlineLabel(
-                    ctx,
-                    trendText,
-                    x1_px, 
-                    y1_px,
-                    x2_px,
-                    y2_px,
+                addTrendlineLabel(ctx, {
+                    label: trendText,
+                    x1: x1_px,
+                    y1: y1_px,
+                    x2: x2_px,
+                    y2: y2_px,
                     angle,
-                    color,
+                    labelColor: color,
                     family,
                     size,
-                    offset
-                );
+                    offset,
+                });
             }
         }
     } else {

--- a/src/components/trendline.test.js
+++ b/src/components/trendline.test.js
@@ -623,16 +623,13 @@ describe('addFitter - Exponential Trendlines', () => {
         
         expect(labelUtils.addTrendlineLabel).toHaveBeenCalledWith(
             mockCtx,
-            'Exponential Trend (a=2.05, b=0.48)',
-            expect.any(Number),
-            expect.any(Number),
-            expect.any(Number),
-            expect.any(Number),
-            expect.any(Number),
-            'black',
-            'Arial',
-            12,
-            5
+            expect.objectContaining({
+                label: 'Exponential Trend (a=2.05, b=0.48)',
+                labelColor: 'black',
+                family: 'Arial',
+                size: 12,
+                offset: 5,
+            })
         );
     });
 


### PR DESCRIPTION
## Summary
Code simplification: replaced 11 individual positional parameters in `addTrendlineLabel` with a single options object, making the function signature more maintainable and reducing cognitive load when calling it.

### Changes
- `src/components/label.js`: Changed signature from `(ctx, label, x1, y1, x2, y2, angle, labelColor, family, size, offset)` to `(ctx, options)` with destructuring
- `src/components/trendline.js`: Updated the call site to pass an options object with named properties
- `src/components/label.test.js`: Updated all 5 test cases to use new calling convention
- `src/components/trendline.test.js`: Updated the exponential trendline label assertion

## Test
- [x] All 125 tests pass