### PR TITLE
refactor: extract validateFiniteCoords helper in drawing.js

### DIFF
--- a/SIMPLIFY_PLAN.md
+++ b/SIMPLIFY_PLAN.md
@@ -5,7 +5,7 @@ Varje cron-run plockar nästa ocheckade punkt, gör en refactoring-branch med ti
 ## Kö
 
 - [x] **refactor/label-to-options** — `label.js`: ersätt 11 individuella parametrar med ett options-objekt. Uppdatera `addTrendlineLabel`-signaturen och alla anrop.
-- [ ] **refactor/drawing-shared-validation** — `drawing.js`: extrahera `validateFiniteCoords` helper från `drawTrendline` och `fillBelowTrendline` för att eliminera duplicerad sanity-check-kod.
+- [x] **refactor/drawing-shared-validation** — `drawing.js`: extrahera `validateFiniteCoords` helper från `drawTrendline` och `fillBelowTrendline` för att eliminera duplicerad sanity-check-kod.
 - [ ] **refactor/plugin-legend-cleanup** — `plugin.js`: förenkla `beforeInit` legend-logiken. Extract:a legend-item-skapande till en egen funktion.
 - [ ] **refactor/trendline-data-extraction** — `trendline.js`: bryt ut datainsamlingslogiken (forEach-loopen) ur `addFitter` till en egen `collectDataPoints`-funktion.
 - [ ] **refactor/trendline-projection** — `trendline.js`: bryt ut projection-koordinatberäkningen ur `addFitter` till en egen funktion.

--- a/src/utils/drawing.js
+++ b/src/utils/drawing.js
@@ -37,6 +37,25 @@ export const setLineStyle = (ctx, lineStyle) => {
 };
 
 /**
+ * Validates that all provided named coordinate values are finite numbers.
+ * @param {Object<string, number>} coords - Named coordinate values to validate.
+ * @param {string} label - Label for the warning message (e.g., 'draw trendline').
+ * @returns {boolean} - True if all values are finite, false otherwise.
+ */
+const validateFiniteCoords = (coords, label) => {
+    for (const value of Object.values(coords)) {
+        if (!isFinite(value)) {
+            console.warn(
+                `Cannot ${label}: coordinates contain non-finite values`,
+                coords
+            );
+            return false;
+        }
+    }
+    return true;
+};
+
+/**
  * Draws the trendline on the canvas context.
  * @param {Object} params - The trendline parameters.
  * @param {CanvasRenderingContext2D} params.ctx - The canvas rendering context.
@@ -48,14 +67,7 @@ export const setLineStyle = (ctx, lineStyle) => {
  * @param {string} params.colorMax - The ending color of the trendline gradient.
  */
 export const drawTrendline = ({ ctx, x1, y1, x2, y2, colorMin, colorMax }) => {
-    // Ensure all values are finite numbers
-    if (!isFinite(x1) || !isFinite(y1) || !isFinite(x2) || !isFinite(y2)) {
-        console.warn(
-            'Cannot draw trendline: coordinates contain non-finite values',
-            { x1, y1, x2, y2 }
-        );
-        return;
-    }
+    if (!validateFiniteCoords({ x1, y1, x2, y2 }, 'draw trendline')) return;
 
     ctx.beginPath();
     ctx.moveTo(x1, y1);
@@ -98,20 +110,7 @@ export const drawTrendline = ({ ctx, x1, y1, x2, y2, colorMin, colorMax }) => {
  * @param {string} fillColor - The color to fill below the trendline.
  */
 export const fillBelowTrendline = (ctx, x1, y1, x2, y2, drawBottom, fillColor) => {
-    // Ensure all values are finite numbers
-    if (
-        !isFinite(x1) ||
-        !isFinite(y1) ||
-        !isFinite(x2) ||
-        !isFinite(y2) ||
-        !isFinite(drawBottom)
-    ) {
-        console.warn(
-            'Cannot fill below trendline: coordinates contain non-finite values',
-            { x1, y1, x2, y2, drawBottom }
-        );
-        return;
-    }
+    if (!validateFiniteCoords({ x1, y1, x2, y2, drawBottom }, 'fill below trendline')) return;
 
     ctx.beginPath();
     ctx.moveTo(x1, y1);


### PR DESCRIPTION
## Summary
Code simplification: extract shared `validateFiniteCoords` helper function from duplicated coordinate validation logic in `drawTrendline` and `fillBelowTrendline`.

- Both functions had identical `!isFinite()` checks with similar warning messages
- Extracted into a `validateFiniteCoords(coords, label)` helper that accepts named coordinate objects
- 22 lines reduced to 21 cleaner lines (+helper doc, -duplicated logic)
- Behavior and warning messages are identical

## Test
- [x] All 125 tests pass