### PR TITLE
refactor: extract collectDataPoints from addFitter

### DIFF
--- a/SIMPLIFY_PLAN.md
+++ b/SIMPLIFY_PLAN.md
@@ -7,7 +7,7 @@ Varje cron-run plockar nästa ocheckade punkt, gör en refactoring-branch med ti
 - [x] **refactor/label-to-options** — `label.js`: ersätt 11 individuella parametrar med ett options-objekt. Uppdatera `addTrendlineLabel`-signaturen och alla anrop.
 - [x] **refactor/drawing-shared-validation** — `drawing.js`: extrahera `validateFiniteCoords` helper från `drawTrendline` och `fillBelowTrendline` för att eliminera duplicerad sanity-check-kod.
 - [x] **refactor/plugin-legend-cleanup** — `plugin.js`: förenkla `beforeInit` legend-logiken. Extract:a legend-item-skapande till en egen funktion.
-- [ ] **refactor/trendline-data-extraction** — `trendline.js`: bryt ut datainsamlingslogiken (forEach-loopen) ur `addFitter` till en egen `collectDataPoints`-funktion.
+- [x] **refactor/trendline-data-extraction** — `trendline.js`: bryt ut datainsamlingslogiken (forEach-loopen) ur `addFitter` till en egen `collectDataPoints`-funktion.
 - [ ] **refactor/trendline-projection** — `trendline.js`: bryt ut projection-koordinatberäkningen ur `addFitter` till en egen funktion.
 - [ ] **refactor/fitter-base-class** — `lineFitter.js` + `exponentialFitter.js`: skapa en gemensam basklass för delad caching- och summeringslogik.
 - [ ] **refactor/index-browser-check** — `index.js`: förenkla browser detection med modernare pattern.

--- a/src/components/trendline.js
+++ b/src/components/trendline.js
@@ -4,6 +4,78 @@ import { drawTrendline, fillBelowTrendline, setLineStyle } from '../utils/drawin
 import { addTrendlineLabel } from './label.js';
 
 /**
+ * Collects valid data points from a dataset and adds them to the fitter.
+ * Handles null/undefined values, trendoffset logic, time scales, and different
+ * data structures (object {x,y} vs array of numbers).
+ * @param {Object} fitter - The fitter instance (LineFitter or ExponentialFitter).
+ * @param {Object} dataset - The dataset configuration from the chart.
+ * @param {number} trendoffset - Number of data points to skip (positive from start, negative from end).
+ * @param {number} effectiveFirstIndex - The index of the first valid data point.
+ * @param {boolean} xy - Whether the data is structured as objects {x,y}.
+ * @param {Scale} xScale - The x-axis scale object.
+ * @param {string} xAxisKey - Key for x-values in object data.
+ * @param {string} yAxisKey - Key for y-values in object data.
+ * @param {Array} chartLabels - Labels array from chart (for time scales with array data).
+ */
+export const collectDataPoints = (fitter, dataset, trendoffset, effectiveFirstIndex, xy, xScale, xAxisKey, yAxisKey, chartLabels) => {
+    dataset.data.forEach((data, index) => {
+        // Skip any data point that is null or undefined directly. This is a general guard.
+        if (data == null) return; 
+        
+        // Apply trendoffset logic for including/excluding points:
+        // 1. Positive offset: Skip data points if their index is before the `effectiveFirstIndex`.
+        //    `effectiveFirstIndex` already accounts for the offset and initial nulls.
+        if (trendoffset > 0 && index < effectiveFirstIndex) return;
+        // 2. Negative offset: Skip data points if their index is at or after the calculated end point.
+        //    `dataset.data.length + trendoffset` marks the first index of the points to be excluded from the end.
+        //    For example, if length is 10 and offset is -2, points from index 8 onwards are skipped.
+        if (trendoffset < 0 && index >= dataset.data.length + trendoffset) return;
+
+        // Process data based on scale type and data structure.
+        if (['time', 'timeseries'].includes(xScale.options.type) && xy) {
+            // For time-based scales with object data, convert x to a numerical timestamp; ensure y is a valid number.
+            let x = data[xAxisKey] != null ? data[xAxisKey] : data.t; // `data.t` is a Chart.js internal fallback for time data.
+            const yValue = data[yAxisKey];
+
+            // Both x and y must be valid for the point to be included.
+            if (x != null && x !== undefined && yValue != null && !isNaN(yValue)) {
+                fitter.add(new Date(x).getTime(), yValue);
+            }
+            // If x or yValue is invalid, the point is skipped.
+        } else if (xy) { // Data is identified as array of objects {x,y}.
+            const xVal = data[xAxisKey];
+            const yVal = data[yAxisKey];
+
+            const xIsValid = xVal != null && !isNaN(xVal);
+            const yIsValid = yVal != null && !isNaN(yVal);
+
+            // Both xVal and yVal must be valid numbers to include the point.
+            if (xIsValid && yIsValid) {
+                fitter.add(xVal, yVal);
+            }
+            // If either xVal or yVal is invalid, the point is skipped. No fallback to using index.
+        } else if (['time', 'timeseries'].includes(xScale.options.type) && !xy) {
+            // For time-based scales with array of numbers, get the x-value from the chart labels
+            if (chartLabels && chartLabels[index] && data != null && !isNaN(data)) {
+                const timeValue = new Date(chartLabels[index]).getTime();
+                if (!isNaN(timeValue)) {
+                    fitter.add(timeValue, data);
+                }
+            }
+        } else { 
+            // Data is an array of numbers (or other non-object types).
+            // The 'data' variable itself is the y-value, and 'index' is the x-value.
+            // We still need to check for null/NaN here because 'data' (the y-value) could be null/NaN
+            // even if the entry 'data' (the point/container) wasn't null in the initial check.
+            // This applies if dataset.data = [1, 2, null, 4].
+            if (data != null && !isNaN(data)) {
+                 fitter.add(index, data);
+            }
+        }
+    });
+};
+
+/**
  * Adds a trendline (fitter) to the dataset on the chart and optionally labels it with trend value.
  * @param {Object} datasetMeta - Metadata about the dataset.
  * @param {CanvasRenderingContext2D} ctx - The canvas rendering context.
@@ -56,8 +128,8 @@ export const addFitter = (datasetMeta, ctx, dataset, xScale, yScale) => {
 
     let fitter = isExponential ? new ExponentialFitter() : new LineFitter();
     
-    // --- Data Point Collection and Validation for LineFitter ---
-
+    // --- Data Point Collection and Validation ---
+    
     // Sanitize trendoffset: if its absolute value is too large, reset to 0.
     // This prevents errors if offset is out of bounds of the dataset length.
     if (Math.abs(trendoffset) >= dataset.data.length) trendoffset = 0;
@@ -89,65 +161,10 @@ export const addFitter = (datasetMeta, ctx, dataset, xScale, yScale) => {
     
     // Determine data structure type (object {x,y} or array of numbers) based on the first valid data point.
     // This informs how `xAxisKey` and `yAxisKey` are used or if `index` is used for x-values.
-    let xy = effectiveFirstIndex < dataset.data.length && typeof dataset.data[effectiveFirstIndex] === 'object';
+    const xy = effectiveFirstIndex < dataset.data.length && typeof dataset.data[effectiveFirstIndex] === 'object';
 
-    // Iterate over dataset to collect points for the LineFitter.
-    dataset.data.forEach((data, index) => {
-        // Skip any data point that is null or undefined directly. This is a general guard.
-        if (data == null) return; 
-        
-        // Apply trendoffset logic for including/excluding points:
-        // 1. Positive offset: Skip data points if their index is before the `effectiveFirstIndex`.
-        //    `effectiveFirstIndex` already accounts for the offset and initial nulls.
-        if (trendoffset > 0 && index < effectiveFirstIndex) return;
-        // 2. Negative offset: Skip data points if their index is at or after the calculated end point.
-        //    `dataset.data.length + trendoffset` marks the first index of the points to be excluded from the end.
-        //    For example, if length is 10 and offset is -2, points from index 8 onwards are skipped.
-        if (trendoffset < 0 && index >= dataset.data.length + trendoffset) return;
-
-        // Process data based on scale type and data structure.
-        if (['time', 'timeseries'].includes(xScale.options.type) && xy) {
-            // For time-based scales with object data, convert x to a numerical timestamp; ensure y is a valid number.
-            let x = data[xAxisKey] != null ? data[xAxisKey] : data.t; // `data.t` is a Chart.js internal fallback for time data.
-            const yValue = data[yAxisKey];
-
-            // Both x and y must be valid for the point to be included.
-            if (x != null && x !== undefined && yValue != null && !isNaN(yValue)) {
-                fitter.add(new Date(x).getTime(), yValue);
-            }
-            // If x or yValue is invalid, the point is skipped.
-        } else if (xy) { // Data is identified as array of objects {x,y}.
-            const xVal = data[xAxisKey];
-            const yVal = data[yAxisKey];
-
-            const xIsValid = xVal != null && !isNaN(xVal);
-            const yIsValid = yVal != null && !isNaN(yVal);
-
-            // Both xVal and yVal must be valid numbers to include the point.
-            if (xIsValid && yIsValid) {
-                fitter.add(xVal, yVal);
-            }
-            // If either xVal or yVal is invalid, the point is skipped. No fallback to using index.
-        } else if (['time', 'timeseries'].includes(xScale.options.type) && !xy) {
-            // For time-based scales with array of numbers, get the x-value from the chart labels
-            const chartLabels = datasetMeta.controller.chart.data.labels;
-            if (chartLabels && chartLabels[index] && data != null && !isNaN(data)) {
-                const timeValue = new Date(chartLabels[index]).getTime();
-                if (!isNaN(timeValue)) {
-                    fitter.add(timeValue, data);
-                }
-            }
-        } else { 
-            // Data is an array of numbers (or other non-object types).
-            // The 'data' variable itself is the y-value, and 'index' is the x-value.
-            // We still need to check for null/NaN here because 'data' (the y-value) could be null/NaN
-            // even if the entry 'data' (the point/container) wasn't null in the initial check.
-            // This applies if dataset.data = [1, 2, null, 4].
-            if (data != null && !isNaN(data)) {
-                 fitter.add(index, data);
-            }
-        }
-    });
+    const chartLabels = datasetMeta.controller.chart.data.labels;
+    collectDataPoints(fitter, dataset, trendoffset, effectiveFirstIndex, xy, xScale, xAxisKey, yAxisKey, chartLabels);
 
     // --- Trendline Coordinate Calculation ---
     // Ensure there are enough points to form a trendline.

--- a/src/components/trendline.test.js
+++ b/src/components/trendline.test.js
@@ -1,4 +1,4 @@
-import { addFitter } from './trendline.js';
+import { addFitter, collectDataPoints } from './trendline.js';
 import 'jest-canvas-mock';
 
 import { LineFitter } from '../utils/lineFitter.js';
@@ -486,6 +486,142 @@ describe('addFitter', () => {
     });
 });
 
+describe('collectDataPoints', () => {
+    let mockXScale;
+    let mockDataset;
+
+    beforeEach(() => {
+        mockXScale = {
+            options: { type: 'linear' },
+        };
+        mockDataset = {
+            data: [
+                { x: 10, y: 30 },
+                { x: 20, y: 50 },
+                { x: 30, y: 70 },
+            ],
+        };
+    });
+
+    test('adds all valid object data points to fitter', () => {
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(3);
+        expect(fitter.sumx).toBe(60);
+        expect(fitter.sumy).toBe(150);
+    });
+
+    test('skips null and undefined data points', () => {
+        mockDataset.data = [
+            { x: 10, y: 30 },
+            null,
+            { x: 20, y: 50 },
+            undefined,
+            { x: 30, y: 70 },
+        ];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(3);
+        expect(fitter.sumx).toBe(60);
+        expect(fitter.sumy).toBe(150);
+    });
+
+    test('positive trendoffset skips initial data points', () => {
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 1, 1, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(2);
+        expect(fitter.sumx).toBe(50);
+        expect(fitter.sumy).toBe(120);
+    });
+
+    test('negative trendoffset skips trailing data points', () => {
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, -1, 0, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(2);
+        expect(fitter.sumx).toBe(30);
+        expect(fitter.sumy).toBe(80);
+    });
+
+    test('handles array of numbers (non-object data)', () => {
+        mockDataset.data = [10, 20, 30, 40, 50];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, false, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(5);
+        // x-values are indices: 0,1,2,3,4
+        expect(fitter.sumx).toBe(10);
+        expect(fitter.sumy).toBe(150);
+    });
+
+    test('skips NaN values in array data', () => {
+        mockDataset.data = [10, null, 30, undefined, 50];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, false, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(3);
+        expect(fitter.sumx).toBe(6); // indices 0, 2, 4
+        expect(fitter.sumy).toBe(90);
+    });
+
+    test('handles time scale with object data', () => {
+        mockXScale.options.type = 'time';
+        const date1 = new Date('2023-01-01T00:00:00.000Z');
+        const date2 = new Date('2023-01-02T00:00:00.000Z');
+        mockDataset.data = [
+            { x: date1.toISOString(), y: 10 },
+            { x: date2.toISOString(), y: 20 },
+        ];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(2);
+        expect(fitter.sumx).toBe(date1.getTime() + date2.getTime());
+        expect(fitter.sumy).toBe(30);
+    });
+
+    test('handles time scale with array data using chart labels', () => {
+        mockXScale.options.type = 'timeseries';
+        mockDataset.data = [75, 64, 52];
+        const chartLabels = [
+            '2025-03-01T00:00:00',
+            '2025-03-02T00:00:00',
+            '2025-03-03T00:00:00',
+        ];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, false, mockXScale, 'x', 'y', chartLabels);
+        expect(fitter.count).toBe(3);
+        expect(fitter.sumx).toBe(
+            new Date('2025-03-01T00:00:00').getTime() +
+            new Date('2025-03-02T00:00:00').getTime() +
+            new Date('2025-03-03T00:00:00').getTime()
+        );
+        expect(fitter.sumy).toBe(191);
+    });
+
+    test('skips points with missing x or y in object data', () => {
+        mockDataset.data = [
+            { x: 10, y: 30 },
+            { x: 20 },       // missing y
+            { y: 70 },       // missing x
+            { value: 90 },   // wrong key
+            { x: 40, y: 80 },
+        ];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, true, mockXScale, 'x', 'y', []);
+        expect(fitter.count).toBe(2);
+        expect(fitter.sumx).toBe(50);
+        expect(fitter.sumy).toBe(110);
+    });
+
+    test('uses custom xAxisKey and yAxisKey', () => {
+        mockDataset.data = [
+            { customX: 5, customY: 15 },
+            { customX: 10, customY: 25 },
+        ];
+        const fitter = new (jest.requireActual("../utils/lineFitter").LineFitter)();
+        collectDataPoints(fitter, mockDataset, 0, 0, true, mockXScale, 'customX', 'customY', []);
+        expect(fitter.count).toBe(2);
+        expect(fitter.sumx).toBe(15);
+        expect(fitter.sumy).toBe(40);
+    });
+});
 describe('addFitter - Exponential Trendlines', () => {
     let mockCtx;
     let mockDatasetMeta;


### PR DESCRIPTION
## Summary
Extraherar datainsamlingslogiken (forEach-loopen) från `addFitter` till en egen exporterad `collectDataPoints`-funktion.

## Motivation
- Minskar komplexiteten i `addFitter` — den är nu renare och fokuserad på koordinatberäkning och rendering
- `collectDataPoints` kan nu testas och återanvändas separat
- Inga beteendeförändringar — all logik är identisk

## Verification
- ✅ 144 / 144 tests pass
- ✅ 0 vulnerabilities

## Nästa i kön
- **refactor/trendline-projection** — bryt ut projection-koordinatberäkningen från addFitter