### PR TITLE
refactor: extract BaseFitter base class

### DIFF
--- a/SIMPLIFY_PLAN.md
+++ b/SIMPLIFY_PLAN.md
@@ -9,5 +9,5 @@ Varje cron-run plockar nästa ocheckade punkt, gör en refactoring-branch med ti
 - [x] **refactor/plugin-legend-cleanup** — `plugin.js`: förenkla `beforeInit` legend-logiken. Extract:a legend-item-skapande till en egen funktion.
 - [x] **refactor/trendline-data-extraction** — `trendline.js`: bryt ut datainsamlingslogiken (forEach-loopen) ur `addFitter` till en egen `collectDataPoints`-funktion.
 - [x] **refactor/trendline-projection** — `trendline.js`: bryt ut projection-koordinatberäkningen ur `addFitter` till en egen funktion.
-- [ ] **refactor/fitter-base-class** — `lineFitter.js` + `exponentialFitter.js`: skapa en gemensam basklass för delad caching- och summeringslogik.
+- [x] **refactor/fitter-base-class** — `lineFitter.js` + `exponentialFitter.js`: skapa en gemensam `BaseFitter`-klass för delad caching- och summeringslogik.
 - [ ] **refactor/index-browser-check** — `index.js`: förenkla browser detection med modernare pattern.

--- a/src/utils/baseFitter.js
+++ b/src/utils/baseFitter.js
@@ -1,0 +1,36 @@
+/**
+ * A base class for fitter classes that provides shared state and caching logic.
+ * Handles count tracking, x-value accumulation, and min/max tracking.
+ */
+export class BaseFitter {
+    constructor() {
+        this.count = 0;
+        this.sumx = 0;
+        this.sumx2 = 0;
+        this.minx = Number.MAX_VALUE;
+        this.maxx = Number.MIN_VALUE;
+        this._cacheValid = false;
+    }
+
+    /**
+     * Adds a point to the fitter. Shared x-accumulation logic.
+     * Subclasses should call super.add(x) and handle y-specific logic.
+     * @param {number} x - The x-coordinate of the point.
+     */
+    add(x) {
+        this.sumx += x;
+        this.sumx2 += x * x;
+        if (x < this.minx) this.minx = x;
+        if (x > this.maxx) this.maxx = x;
+        this.count++;
+        this._cacheValid = false;
+    }
+
+    /**
+     * Returns the scale (magnitude) of the fitted curve.
+     * @returns {number} - The scale value.
+     */
+    scale() {
+        return 0;
+    }
+}

--- a/src/utils/exponentialFitter.js
+++ b/src/utils/exponentialFitter.js
@@ -1,22 +1,19 @@
+import { BaseFitter } from './baseFitter.js';
+
 /**
  * A class that fits an exponential curve to a series of points using least squares.
  * Fits y = a * e^(b*x) by transforming to ln(y) = ln(a) + b*x
  */
-export class ExponentialFitter {
+export class ExponentialFitter extends BaseFitter {
     constructor() {
-        this.count = 0;
-        this.sumx = 0;
+        super();
         this.sumlny = 0;
-        this.sumx2 = 0;
         this.sumxlny = 0;
-        this.minx = Number.MAX_VALUE;
-        this.maxx = Number.MIN_VALUE;
         this.hasValidData = true;
         this.dataPoints = []; // Store data points for correlation calculation
         this._cachedGrowthRate = null;
         this._cachedCoefficient = null;
         this._cachedCorrelation = null;
-        this._cacheValid = false;
     }
 
     /**
@@ -36,15 +33,10 @@ export class ExponentialFitter {
             return;
         }
 
-        this.sumx += x;
+        super.add(x);
         this.sumlny += lny;
-        this.sumx2 += x * x;
         this.sumxlny += x * lny;
-        if (x < this.minx) this.minx = x;
-        if (x > this.maxx) this.maxx = x;
         this.dataPoints.push({x, y, lny}); // Store actual data points
-        this.count++;
-        this._cacheValid = false;
     }
 
     /**

--- a/src/utils/lineFitter.js
+++ b/src/utils/lineFitter.js
@@ -1,18 +1,15 @@
+import { BaseFitter } from './baseFitter.js';
+
 /**
  * A class that fits a line to a series of points using least squares.
  */
-export class LineFitter {
+export class LineFitter extends BaseFitter {
     constructor() {
-        this.count = 0;
-        this.sumx = 0;
+        super();
         this.sumy = 0;
-        this.sumx2 = 0;
         this.sumxy = 0;
-        this.minx = Number.MAX_VALUE;
-        this.maxx = Number.MIN_VALUE;
         this._cachedSlope = null;
         this._cachedIntercept = null;
-        this._cacheValid = false;
     }
 
     /**
@@ -21,14 +18,9 @@ export class LineFitter {
      * @param {number} y - The y-coordinate of the point.
      */
     add(x, y) {
-        this.sumx += x;
+        super.add(x);
         this.sumy += y;
-        this.sumx2 += x * x;
         this.sumxy += x * y;
-        if (x < this.minx) this.minx = x;
-        if (x > this.maxx) this.maxx = x;
-        this.count++;
-        this._cacheValid = false;
     }
 
     /**


### PR DESCRIPTION
## Summary
Skapar en gemensam `BaseFitter`-klass för delad state (count, sumx, sumx2, minx, maxx, \_cacheValid) som både `LineFitter` och `ExponentialFitter` ärver från.

## Förändringar
- **src/utils/baseFitter.js** — ny fil med `BaseFitter` class
- **src/utils/lineFitter.js** — extends BaseFitter, tar bort duplicerad init/update-logik
- **src/utils/exponentialFitter.js** — extends BaseFitter, tar bort duplicerad init/update-logik
- **SIMPLIFY_PLAN.md** — uppdaterad

## Verification
- ✅ Alla 162 tester passerar
- ✅ Ingen beteendeförändring — endast intern refactoring

## Nästa i kön
- **refactor/index-browser-check** — förenkla browser detection i index.js