### PR TITLE
fix: bump js-yaml override to >=3.15.0 (v3.2.7)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "chartjs-plugin-trendline",
-  "version": "3.2.5",
+  "version": "3.2.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chartjs-plugin-trendline",
-      "version": "3.2.5",
+      "version": "3.2.7",
       "license": "MIT",
       "devDependencies": {
-        "@babel/core": "^7.29.7",
+        "@babel/core": "^7.29.6",
         "@babel/preset-env": "^7.29.5",
         "@rollup/plugin-terser": "^1.0.0",
-        "babel-jest": "^30.2.0",
-        "jest": "^30.2.0",
+        "babel-jest": "^30.4.1",
+        "jest": "^30.4.2",
         "jest-canvas-mock": "^2.5.2",
-        "jest-environment-jsdom": "^30.2.0",
-        "rollup": "^4.59.0"
+        "jest-environment-jsdom": "^30.4.1",
+        "rollup": "^4.60.4"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -4900,9 +4900,9 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "dependencies": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-trendline",
-  "version": "3.2.6",
+  "version": "3.2.7",
   "description": "Trendline for Chart.js",
   "type": "module",
   "main": "./dist/chartjs-plugin-trendline.cjs",
@@ -39,7 +39,7 @@
   },
   "pnpm": {
     "overrides": {
-      "js-yaml": ">=3.14.2",
+      "js-yaml": ">=3.15.0",
       "serialize-javascript": "^7.0.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  js-yaml: '>=3.14.2'
+  js-yaml: '>=3.15.0'
   serialize-javascript: ^7.0.3
 
 importers:


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert: `js-yaml < 3.15.0` in `package-lock.json`
- Updated `pnpm.overrides` from `>=3.14.2` → `>=3.15.0`
- Regenerated `package-lock.json` (js-yaml now resolves to 3.15.0)
- Updated `pnpm-lock.yaml` override block
- Rebuilt dist/ with new version banner
- Bumped to v3.2.7