### PR TITLE
fix: bump to v3.2.8, security fix for ws (CVE-2026-48779)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6401,10 +6401,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+      "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-trendline",
-  "version": "3.2.7",
+  "version": "3.2.8",
   "description": "Trendline for Chart.js",
   "type": "module",
   "main": "./dist/chartjs-plugin-trendline.cjs",
@@ -37,10 +37,14 @@
     "jest-environment-jsdom": "^30.4.1",
     "rollup": "^4.60.4"
   },
+  "overrides": {
+    "ws": ">=8.21.0"
+  },
   "pnpm": {
     "overrides": {
       "js-yaml": ">=3.15.0",
-      "serialize-javascript": "^7.0.3"
+      "serialize-javascript": "^7.0.3",
+      "ws": ">=8.21.0"
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   js-yaml: '>=3.15.0'
   serialize-javascript: ^7.0.3
+  ws: '>=8.21.0'
 
 importers:
 


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert CVE-2026-48779 (high severity)
- Overrides transitive dep `ws` to `>=8.21.0` in both npm `overrides` and `pnpm.overrides`
- `package-lock.json` updated: ws 8.20.1 → 8.21.1
- `pnpm-lock.yaml` already had ws@8.21.0 (safe)
- Bumped to v3.2.8