### PR TITLE
fix: prevent aria-label duplication on repeated accessibility calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-trendline",
-  "version": "3.2.9",
+  "version": "3.2.10",
   "description": "Trendline for Chart.js",
   "type": "module",
   "main": "./dist/chartjs-plugin-trendline.cjs",

--- a/src/utils/accessibility.js
+++ b/src/utils/accessibility.js
@@ -83,12 +83,19 @@ export function applyCanvasAccessibility(chartInstance) {
     // Generate and apply description
     const description = generateChartTrendlineDescription(chartInstance);
     if (description) {
-        const existingLabel = canvas.getAttribute('aria-label') || '';
-        if (existingLabel) {
-            // Append to existing aria-label if chart already has one
-            canvas.setAttribute('aria-label', `${existingLabel}. ${description}`);
-        } else {
-            canvas.setAttribute('aria-label', description);
+        // Preserve the original user-provided aria-label so repeated calls
+        // (afterInit + afterUpdate) don't accumulate duplicate descriptions.
+        // See: https://github.com/Makanz/chartjs-plugin-trendline/issues/152
+        if (!canvas.hasAttribute('data-trendline-original-label')) {
+            canvas.setAttribute(
+                'data-trendline-original-label',
+                canvas.getAttribute('aria-label') || ''
+            );
         }
+        const originalLabel = canvas.getAttribute('data-trendline-original-label') || '';
+        canvas.setAttribute(
+            'aria-label',
+            originalLabel ? `${originalLabel}. ${description}` : description
+        );
     }
 }

--- a/src/utils/accessibility.test.js
+++ b/src/utils/accessibility.test.js
@@ -185,6 +185,26 @@ describe('applyCanvasAccessibility', () => {
         expect(chartInstance.canvas.hasAttribute('aria-label')).toBe(false);
     });
 
+    it('should not duplicate description on repeated calls (afterInit + afterUpdate)', () => {
+        applyCanvasAccessibility(chartInstance);
+        const firstLabel = chartInstance.canvas.getAttribute('aria-label');
+        applyCanvasAccessibility(chartInstance);
+        const secondLabel = chartInstance.canvas.getAttribute('aria-label');
+        expect(secondLabel).toBe(firstLabel);
+    });
+
+    it('should not duplicate description on repeated calls with pre-existing aria-label', () => {
+        chartInstance.canvas.setAttribute('aria-label', 'My Chart');
+        applyCanvasAccessibility(chartInstance);
+        const firstLabel = chartInstance.canvas.getAttribute('aria-label');
+        applyCanvasAccessibility(chartInstance);
+        const secondLabel = chartInstance.canvas.getAttribute('aria-label');
+        expect(secondLabel).toBe(firstLabel);
+        // Ensure original label appears exactly once
+        const matches = secondLabel.match(/My Chart/g);
+        expect(matches).toHaveLength(1);
+    });
+
     it('should do nothing when canvas is absent', () => {
         const withoutCanvas = { data: { datasets: [] } };
         expect(() => applyCanvasAccessibility(withoutCanvas)).not.toThrow();


### PR DESCRIPTION
## Problem

The trendline description is repeated in the canvas `aria-label`. This can be seen in the [live examples](https://makanz.github.io/chartjs-plugin-trendline/example/barChart.html).

Reported in #152.

## Root cause

`applyCanvasAccessibility` is called on **both** `afterInit` and `afterUpdate` (in `src/core/plugin.js`). The old code in `src/utils/accessibility.js` appended the description to whatever was already in `aria-label`:

```js
const existingLabel = canvas.getAttribute('aria-label') || '';
if (existingLabel) {
    canvas.setAttribute('aria-label', `${existingLabel}. ${description}`);
}
```

So `afterInit` set `aria-label = "Linear trendline for..."`, then `afterUpdate` fired, read that same label as `existingLabel`, and appended the description **again** → duplication. Every subsequent `chart.update()` added another copy.

## Fix

Store the original user-provided `aria-label` in a `data-trendline-original-label` attribute on the first call, then reconstruct the label from that stored original on every subsequent call instead of accumulating.

```js
if (!canvas.hasAttribute('data-trendline-original-label')) {
    canvas.setAttribute('data-trendline-original-label',
        canvas.getAttribute('aria-label') || '');
}
const originalLabel = canvas.getAttribute('data-trendline-original-label') || '';
canvas.setAttribute('aria-label',
    originalLabel ? `${originalLabel}. ${description}` : description);
```

## Tests

Added two test cases to `accessibility.test.js`:
- `should not duplicate description on repeated calls (afterInit + afterUpdate)`
- `should not duplicate description on repeated calls with pre-existing aria-label`

All 167 tests pass.

Fixes #152